### PR TITLE
fix(cron): align scheduler auth and harden cron reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  quality-gate:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,14 +29,78 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Type check
         run: npx tsc --noEmit
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Test
         run: npm run test -- --run
 
+  coverage-critical:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Coverage (Critical Modules)
         run: npm run test:coverage:critical
+
+  e2e-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
@@ -44,6 +108,10 @@ jobs:
       - name: E2E Smoke Tests
         run: npm run test:e2e
 
+  validate-secrets:
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Validate GitHub Secrets
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
@@ -52,6 +120,22 @@ jobs:
             echo "CRON_SECRET is missing in GitHub Secrets!"
             exit 1
           fi
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build
         env:
@@ -73,3 +157,17 @@ jobs:
           DISCORD_ROLE_ID_HOUSING_CHAIR: "mock-role-housing-chair"
           CRON_SECRET: "mock-cron-secret"
         run: npm run build
+
+  quality-gate:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - test
+      - coverage-critical
+      - e2e-smoke
+      - validate-secrets
+      - build
+    steps:
+      - name: Quality gate passed
+        run: echo "All CI checks passed."

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,29 +1,53 @@
 name: Scheduled Cron Job
 
 on:
-    schedule:
-        # Runs every 12 minutes (production only)
-        - cron: "*/12 * * * *"
-    workflow_dispatch:
-        inputs:
-            environment:
-                description: "Target environment"
-                required: true
-                default: "production"
-                type: choice
-                options:
-                    - production
-                    - staging
+  schedule:
+    # Runs every 12 minutes (production only)
+    - cron: "*/12 * * * *"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: "production"
+        type: choice
+        options:
+          - production
+          - staging
 
 jobs:
-    cron:
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        environment: ${{ github.event.inputs.environment || 'production' }}
+  cron:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ github.event.inputs.environment || 'production' }}
+    concurrency:
+      group: cron-${{ github.event.inputs.environment || 'production' }}
+      cancel-in-progress: false
 
-        steps:
-            - name: Trigger cron endpoint
-              run: |
-                  echo "Environment: ${{ github.event.inputs.environment || 'production' }}"
-                  curl -f -X GET \
-                    "${{ secrets.NEXT_PUBLIC_APP_URL }}/api/cron?key=${{ secrets.CRON_SECRET }}&job=HOURLY"
+    steps:
+      - name: Validate required secrets
+        env:
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$NEXT_PUBLIC_APP_URL" ]; then
+            echo "NEXT_PUBLIC_APP_URL is missing in GitHub Secrets."
+            exit 1
+          fi
+
+          if [ -z "$CRON_SECRET" ]; then
+            echo "CRON_SECRET is missing in GitHub Secrets."
+            exit 1
+          fi
+
+      - name: Trigger cron endpoint
+        run: |
+          echo "Environment: ${{ github.event.inputs.environment || 'production' }}"
+          BASE_URL="${{ secrets.NEXT_PUBLIC_APP_URL }}"
+          NORMALIZED_BASE_URL="${BASE_URL%/}"
+          ENDPOINT_URL="${NORMALIZED_BASE_URL}/api/cron?job=HOURLY"
+          curl --fail-with-body --silent --show-error -X GET \
+            --retry 3 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 10 --max-time 60 \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "$ENDPOINT_URL"

--- a/app/api/cron/route.test.ts
+++ b/app/api/cron/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+type CronServiceMock = {
+  runHourly: ReturnType<typeof vi.fn>;
+  expireDuties: ReturnType<typeof vi.fn>;
+  ensureFutureTasks: ReturnType<typeof vi.fn>;
+};
+
+type RouteFixtureOptions = {
+  cronSecret?: string;
+  runHourly?: () => Promise<unknown>;
+  expireDuties?: () => Promise<unknown>;
+  ensureFutureTasks?: () => Promise<unknown>;
+};
+
+async function loadRouteFixture(options: RouteFixtureOptions = {}) {
+  const cronServiceMock: CronServiceMock = {
+    runHourly: vi.fn(options.runHourly ?? (async () => ({ ok: true }))),
+    expireDuties: vi.fn(options.expireDuties ?? (async () => ({ ok: true }))),
+    ensureFutureTasks: vi.fn(
+      options.ensureFutureTasks ?? (async () => ({ ok: true })),
+    ),
+  };
+
+  vi.resetModules();
+
+  vi.doMock("@/lib/infrastructure/config/env", () => ({
+    env: {
+      CRON_SECRET: options.cronSecret ?? "test-secret",
+    },
+  }));
+
+  vi.doMock("@/lib/application/services/jobs/cron.service", () => ({
+    CronService: cronServiceMock,
+  }));
+
+  const routeModule = await import("./route");
+  return { GET: routeModule.GET, cronServiceMock };
+}
+
+function createRequest(job?: string, authToken?: string) {
+  const url = job
+    ? `https://example.com/api/cron?job=${job}`
+    : "https://example.com/api/cron";
+  const headers = new Headers();
+
+  if (authToken) {
+    headers.set("Authorization", `Bearer ${authToken}`);
+  }
+
+  return new Request(url, { method: "GET", headers });
+}
+
+describe("GET /api/cron", () => {
+  it("returns 401 when bearer token is missing", async () => {
+    const { GET } = await loadRouteFixture();
+
+    const response = await GET(createRequest("HOURLY"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toMatchObject({
+      success: false,
+      error: {
+        code: "UNAUTHORIZED",
+      },
+    });
+  }, 15000);
+
+  it("returns 401 when bearer token is invalid", async () => {
+    const { GET } = await loadRouteFixture();
+
+    const response = await GET(createRequest("HOURLY", "invalid"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toMatchObject({
+      success: false,
+      error: {
+        code: "UNAUTHORIZED",
+      },
+    });
+  }, 15000);
+
+  it("returns 400 when job parameter is missing", async () => {
+    const { GET } = await loadRouteFixture();
+
+    const response = await GET(createRequest(undefined, "test-secret"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toMatchObject({
+      success: false,
+      error: {
+        code: "INVALID_JOB",
+      },
+    });
+  }, 15000);
+
+  it("returns 500 when CRON_SECRET is not configured", async () => {
+    const { GET } = await loadRouteFixture({ cronSecret: "" });
+
+    const response = await GET(createRequest("HOURLY", "test-secret"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      success: false,
+      error: {
+        code: "SERVER_CONFIG_ERROR",
+      },
+    });
+  }, 15000);
+
+  it("returns 200 and dispatches HOURLY job", async () => {
+    const hourlyResult = { processed: 7, errors: [] };
+    const { GET, cronServiceMock } = await loadRouteFixture({
+      runHourly: async () => hourlyResult,
+    });
+
+    const response = await GET(createRequest("HOURLY", "test-secret"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(cronServiceMock.runHourly).toHaveBeenCalledTimes(1);
+    expect(payload).toEqual({
+      success: true,
+      result: hourlyResult,
+    });
+  }, 15000);
+
+  it("returns 500 when job execution throws", async () => {
+    const { GET } = await loadRouteFixture({
+      runHourly: async () => {
+        throw new Error("explode");
+      },
+    });
+
+    const response = await GET(createRequest("HOURLY", "test-secret"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      success: false,
+      error: {
+        code: "JOB_EXECUTION_FAILED",
+        message: "explode",
+      },
+    });
+  }, 15000);
+});

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -6,19 +6,42 @@ import { env } from "@/lib/infrastructure/config/env";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic"; // ensure no caching
+const CRON_JOBS = {
+  HOURLY: "HOURLY",
+  EXPIRE_DUTIES: "EXPIRE_DUTIES",
+  ENSURE_FUTURE_TASKS: "ENSURE_FUTURE_TASKS",
+} as const;
+
+function createErrorResponse(
+  status: number,
+  code: string,
+  message: string,
+  job: string | null,
+) {
+  return NextResponse.json(
+    {
+      success: false,
+      error: { code, message, job },
+    },
+    { status },
+  );
+}
 
 export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const job = searchParams.get("job");
+
   try {
-    // 1. Security check: Bearer token from Authorization header
+    // Bearer-token auth keeps this endpoint restricted to trusted schedulers.
     const CRON_SECRET = env.CRON_SECRET;
 
     if (!CRON_SECRET) {
-      console.error(
-        "Cron Job Failed: CRON_SECRET is not configured on the server.",
-      );
-      return NextResponse.json(
-        { error: "Server Configuration Error" },
-        { status: 500 },
+      console.error("[cron] Server configuration error: CRON_SECRET missing");
+      return createErrorResponse(
+        500,
+        "SERVER_CONFIG_ERROR",
+        "Server configuration error",
+        job,
       );
     }
 
@@ -27,40 +50,41 @@ export async function GET(req: Request) {
       ? authHeader.slice(7).trim()
       : null;
     if (!token || token !== CRON_SECRET) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      console.error("[cron] Unauthorized request", { job });
+      return createErrorResponse(401, "UNAUTHORIZED", "Unauthorized", job);
     }
 
-    // 2. Run cron job based on 'job' parameter
-    const { searchParams } = new URL(req.url);
-    const job = searchParams.get("job");
     let result: CronResult | { errors: string[] } | void;
 
     switch (job) {
-      case "HOURLY":
+      case CRON_JOBS.HOURLY:
         result = await CronService.runHourly();
         break;
-      case "EXPIRE_DUTIES":
-        result = await CronService.expireDuties(); // Assuming a method like this exists
+      case CRON_JOBS.EXPIRE_DUTIES:
+        result = await CronService.expireDuties();
         break;
-      case "ENSURE_FUTURE_TASKS":
-        result = await CronService.ensureFutureTasks(); // Assuming a method like this exists
+      case CRON_JOBS.ENSURE_FUTURE_TASKS:
+        result = await CronService.ensureFutureTasks();
         break;
       default:
-        return NextResponse.json(
-          { error: "Invalid or missing job parameter" },
-          { status: 400 },
+        console.error("[cron] Invalid job parameter", { job });
+        return createErrorResponse(
+          400,
+          "INVALID_JOB",
+          "Invalid or missing job parameter",
+          job,
         );
     }
 
-    // 3. Log result for GitHub Actions visibility
-    console.log("Cron Result:", JSON.stringify(result));
+    console.log("[cron] Job completed", {
+      job,
+      result: JSON.stringify(result),
+    });
 
     return NextResponse.json({ success: true, result });
   } catch (e: unknown) {
-    console.error("❌ Cron Job Failed:", e);
-    return NextResponse.json(
-      { error: e instanceof Error ? e.message : "Unknown error" },
-      { status: 500 },
-    );
+    const message = e instanceof Error ? e.message : "Unknown error";
+    console.error("[cron] Job failed", { job, message, error: e });
+    return createErrorResponse(500, "JOB_EXECUTION_FAILED", message, job);
   }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Project Log
 
+## 2026-03-14: Cron Reliability Hardening
+
+- **Cron contract fix**:
+  - Updated `.github/workflows/cron.yml` to call `/api/cron?job=HOURLY` with `Authorization: Bearer <CRON_SECRET>` (matching API route auth).
+  - Added URL normalization, `curl` retries/timeouts, and explicit secret preflight checks.
+  - Added workflow concurrency grouping to avoid overlapping scheduled runs.
+- **API diagnostics**:
+  - Improved `app/api/cron/route.ts` error responses with stable error codes (`UNAUTHORIZED`, `INVALID_JOB`, `SERVER_CONFIG_ERROR`, `JOB_EXECUTION_FAILED`) and structured logging by job.
+- **Regression protection**:
+  - Added `app/api/cron/route.test.ts` covering auth failures, invalid job, missing server secret, success dispatch, and execution exceptions.
+  - Refactored `.github/workflows/ci.yml` into explicit gate jobs (lint, typecheck, tests, coverage, e2e, secret validation, build) plus aggregate `quality-gate`.
+- **Validation snapshot**:
+  - Manual `workflow_dispatch` runs confirmed current remote `staging` and `main` cron workflows still fail with `curl` exit `22` and HTTP `500` while using the legacy query-key call path.
+
 ## 2026-03-13: Library Upload Auth + Metadata Stability Fix
 
 - **Upload auth correctness**:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,3 +120,5 @@ If this command fails, do not promote staging to production until the failing ch
 - GitHub Actions workflow (`cron.yml`) runs on a `*/12 * * * *` schedule (every 12 minutes). The endpoint call uses `job=HOURLY` as a logical job name — it refers to the batch of hourly-cadence tasks (unlock, notify, expire) that are safe to run more frequently than once per hour.
 - **Scheduled runs** always target the `production` environment (the schedule trigger has no environment input).
 - **Manual runs** (`workflow_dispatch`) allow selecting `production` or `staging` via the `environment` input, which controls which GitHub Environment secrets (and therefore which `NEXT_PUBLIC_APP_URL` and `CRON_SECRET`) are used.
+- The cron endpoint authenticates with `Authorization: Bearer <CRON_SECRET>`. Do not pass the secret as a query parameter.
+- The workflow uses retry and timeout safeguards (`--retry`, `--connect-timeout`, `--max-time`) and a concurrency group so overlapping cron runs are prevented.


### PR DESCRIPTION
## Summary
- Align cron workflow auth with the `/api/cron` contract by sending `Authorization: Bearer <CRON_SECRET>` and keeping only `job=HOURLY` in query params.
- Harden scheduled runs with secret preflight checks, URL normalization, retry/timeout curl flags, and workflow concurrency to prevent overlap.
- Add `/api/cron` regression tests, improve route diagnostics, split CI into explicit gates, and document the incident/remediation path.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test -- --run app/api/cron/route.test.ts`
- [ ] `npm run test -- --run` (currently has pre-existing unrelated timeouts in this branch)
- [ ] Trigger `cron.yml` on `staging` after merge and verify successful 2xx run
- [ ] Trigger `cron.yml` on `main`/`production` after staging verification

## Notes
- Pre-fix manual runs on remote `staging` and `main` still showed legacy `?key=` workflow command and failed with `curl (22)` + HTTP 500.
- This PR updates both workflow contract and endpoint diagnostics so post-merge runs should provide actionable output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened cron job authentication with Bearer token validation.
  * Added retry mechanisms and timeouts to cron endpoint invocations.
  * Improved error handling with structured error responses and contextual logging for failed jobs.

* **Documentation**
  * Updated deployment guide with cron authentication and workflow safeguards.
  * Added changelog documenting cron reliability enhancements and regression protection measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->