### PR TITLE
docs(agents): require debug outputs outside repo root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,3 +185,4 @@ If real credentials are not needed (e.g., for lint/test/build only), set `SKIP_E
 - Tests mock `server-only` in `vitest.setup.ts` so they run without any external services.
 - ESLint uses flat config (`eslint.config.mjs`). All rules are warnings — lint passes with 0 errors.
 - The `scripts/` directory is excluded from both ESLint and TypeScript compilation.
+- Ad-hoc debug outputs (API dumps, probe JSON, temporary logs) must be written outside the repository root (prefer Cursor workspace/temp paths). Do not commit debug artifacts.


### PR DESCRIPTION
## Summary
- Add a persistent AGENTS guardrail requiring ad-hoc debug outputs to be written outside the repository root.
- Prefer Cursor workspace/temp paths for temporary API dumps and probe files.
- Prevent accidental debug artifact commits in future debugging sessions.

## Test plan
- [x] Documentation-only change.