### PR TITLE
fix(cron): read URL from env vars and improve diagnostics

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,20 +25,20 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Validate required secrets
+      - name: Validate required scheduler configuration
         env:
-          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+          NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
           set -euo pipefail
 
           if [ -z "$NEXT_PUBLIC_APP_URL" ]; then
-            echo "NEXT_PUBLIC_APP_URL is missing in GitHub Secrets."
+            echo "NEXT_PUBLIC_APP_URL is missing in GitHub Environment Variables."
             exit 1
           fi
 
           if [ -z "$CRON_SECRET" ]; then
-            echo "CRON_SECRET is missing in GitHub Secrets."
+            echo "CRON_SECRET is missing in GitHub Environment Secrets."
             exit 1
           fi
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Preflight cron auth/config contract
         env:
-          BASE_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+          BASE_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
           set -euo pipefail
@@ -60,6 +60,7 @@ jobs:
           echo "Preflight URL: ${PREFLIGHT_URL}"
 
           response_file="$(mktemp)"
+          curl_exit=0
           http_status="$(
             curl --silent --show-error \
               --connect-timeout 10 --max-time 30 \
@@ -68,19 +69,38 @@ jobs:
               -o "${response_file}" \
               -w "%{http_code}" \
               "${PREFLIGHT_URL}"
-          )"
+          )" || curl_exit=$?
 
-          if [ "${http_status}" != "400" ]; then
-            echo "Cron preflight failed. Expected HTTP 400 (invalid job), got HTTP ${http_status}."
-            echo "Response body:"
-            cat "${response_file}"
+          if [ "${curl_exit}" -ne 0 ]; then
+            echo "Cron preflight failed to reach endpoint (curl exit ${curl_exit})."
+            if [ -s "${response_file}" ]; then
+              echo "Response body:"
+              cat "${response_file}"
+            fi
             exit 1
           fi
 
-          if ! grep -q '"code":"INVALID_JOB"' "${response_file}"; then
+          body="$(cat "${response_file}")"
+
+          if [ "${http_status}" != "400" ]; then
+            echo "Cron preflight failed. Expected HTTP 400 (invalid job), got HTTP ${http_status}."
+            if [ -n "${body}" ]; then
+              echo "Response body:"
+              echo "${body}"
+            fi
+            if [[ "${body}" == *"Server Configuration Error"* ]]; then
+              echo "Diagnostic: platform/runtime reports a server configuration issue before cron contract validation."
+              echo "Check deployed runtime env for CRON_SECRET and ensure deployment has completed."
+            fi
+            exit 1
+          fi
+
+          if [[ "${body}" != *"\"code\":\"INVALID_JOB\""* ]]; then
             echo "Cron preflight failed. Expected INVALID_JOB response body."
-            echo "Response body:"
-            cat "${response_file}"
+            if [ -n "${body}" ]; then
+              echo "Response body:"
+              echo "${body}"
+            fi
             exit 1
           fi
 
@@ -88,14 +108,16 @@ jobs:
 
       - name: Trigger cron endpoint
         env:
-          BASE_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+          BASE_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
           set -euo pipefail
           echo "Environment: ${{ github.event.inputs.environment || 'production' }}"
           NORMALIZED_BASE_URL="${BASE_URL%/}"
           ENDPOINT_URL="${NORMALIZED_BASE_URL}/api/cron?job=HOURLY"
+          echo "Cron URL: ${ENDPOINT_URL}"
           response_file="$(mktemp)"
+          curl_exit=0
           http_status="$(
             curl --silent --show-error -X GET \
               --retry 3 --retry-all-errors --retry-delay 2 \
@@ -104,12 +126,25 @@ jobs:
               -o "${response_file}" \
               -w "%{http_code}" \
               "${ENDPOINT_URL}"
-          )"
+          )" || curl_exit=$?
+
+          if [ "${curl_exit}" -ne 0 ]; then
+            echo "Cron HOURLY request failed to reach endpoint (curl exit ${curl_exit})."
+            if [ -s "${response_file}" ]; then
+              echo "Response body:"
+              cat "${response_file}"
+            fi
+            exit 1
+          fi
+
+          body="$(cat "${response_file}")"
 
           if [ "${http_status}" != "200" ]; then
             echo "Cron HOURLY execution failed with HTTP ${http_status}."
-            echo "Response body:"
-            cat "${response_file}"
+            if [ -n "${body}" ]; then
+              echo "Response body:"
+              echo "${body}"
+            fi
             exit 1
           fi
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -135,9 +135,9 @@ If this command fails, do not promote staging to production until the failing ch
 3. In Appwrite Console for the target site (staging or production), verify:
    - `CRON_SECRET` is present and non-empty.
    - `NEXT_PUBLIC_APP_URL` matches the deployed site URL for that environment.
-4. Confirm GitHub Environment secrets (`staging` or `production`) match Appwrite runtime values for:
-   - `NEXT_PUBLIC_APP_URL`
-   - `CRON_SECRET`
+4. Confirm GitHub Environment configuration (`staging` or `production`) matches Appwrite runtime values:
+   - variable: `NEXT_PUBLIC_APP_URL`
+   - secret: `CRON_SECRET`
 5. Re-deploy only if Appwrite environment values changed (Appwrite does not always apply env edits to already-running builds).
 6. Re-run manual cron dispatch after preflight passes:
    - `gh workflow run cron.yml --ref staging -f environment=staging`
@@ -147,6 +147,6 @@ If this command fails, do not promote staging to production until the failing ch
 
 - GitHub Actions workflow (`cron.yml`) runs on a `*/12 * * * *` schedule (every 12 minutes). The endpoint call uses `job=HOURLY` as a logical job name — it refers to the batch of hourly-cadence tasks (unlock, notify, expire) that are safe to run more frequently than once per hour.
 - **Scheduled runs** always target the `production` environment (the schedule trigger has no environment input).
-- **Manual runs** (`workflow_dispatch`) allow selecting `production` or `staging` via the `environment` input, which controls which GitHub Environment secrets (and therefore which `NEXT_PUBLIC_APP_URL` and `CRON_SECRET`) are used.
+- **Manual runs** (`workflow_dispatch`) allow selecting `production` or `staging` via the `environment` input, which controls which GitHub Environment values are used (`NEXT_PUBLIC_APP_URL` from environment variable, `CRON_SECRET` from environment secret).
 - The cron endpoint authenticates with `Authorization: Bearer <CRON_SECRET>`. Do not pass the secret as a query parameter.
 - The workflow uses retry and timeout safeguards (`--retry`, `--connect-timeout`, `--max-time`) and a concurrency group so overlapping cron runs are prevented.


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_APP_URL` from GitHub Environment variables (`vars`) instead of secrets to match current environment configuration
- improve cron workflow diagnostics for network/curl failures and include targeted hints when platform-style server config errors are returned
- update deployment docs to reflect the variable/secret split (`NEXT_PUBLIC_APP_URL` variable, `CRON_SECRET` secret)

## Operational cleanup
- removed stale repository-level `NEXT_PUBLIC_APP_URL` secret so cron resolves URL only from environment-scoped values

## Test plan
- [x] `npm run test -- --run app/api/cron/route.test.ts`
- [ ] run `workflow_dispatch` for `staging` and verify preflight behavior with updated config source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled job validation with enhanced error handling, endpoint verification, and diagnostic logging for better troubleshooting.

* **Documentation**
  * Clarified deployment configuration guidance for environment variable and secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->