### PR TITLE
feat(housing): cron recurrence stabilization and overdue unification

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -124,6 +124,8 @@ export async function GET(req: Request) {
       job,
       allowedJobs: ALLOWED_JOBS,
       hasResult: result !== undefined,
+      resultType: typeof result,
+      completedAt: new Date().toISOString(),
     });
 
     return NextResponse.json({ success: true, result });

--- a/components/features/housing/EditTaskModal.tsx
+++ b/components/features/housing/EditTaskModal.tsx
@@ -225,14 +225,24 @@ export default function EditTaskModal({
           : undefined,
       });
       if (result.success) {
-        toast.success("Task deleted");
+        const successMessage =
+          isRecurring && task.schedule_id
+            ? mutationScope === "entire_series"
+              ? "Recurring series deleted and schedule deactivated"
+              : mutationScope === "this_and_future"
+                ? "Task and future recurring instances deleted"
+                : "Recurring task instance deleted"
+            : "Task deleted";
+        toast.success(successMessage);
         onRefresh();
         onClose();
       } else {
         toast.error(result.error || "Delete failed");
       }
-    } catch {
-      toast.error("Failed to delete");
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "Failed to delete";
+      toast.error(message);
     } finally {
       setLoading(false);
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,40 +4,40 @@ Project documentation for Tau Nu Fiji — The Digital Chapter.
 
 ## Contents
 
-| Document | Description |
-|---|---|
-| [Product Definition](product.md) | What the product does, who it's for, key modules |
-| [Tech Stack](tech-stack.md) | Frameworks, services, and tooling |
-| [Architecture](architecture.md) | Clean Architecture layers, patterns, authentication flow |
-| [Deployment](deployment.md) | CI/CD pipeline, staging/production workflow, secret management |
+| Document                                  | Description                                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------- |
+| [Product Definition](product.md)          | What the product does, who it's for, key modules                             |
+| [Tech Stack](tech-stack.md)               | Frameworks, services, and tooling                                            |
+| [Architecture](architecture.md)           | Clean Architecture layers, patterns, authentication flow                     |
+| [Deployment](deployment.md)               | CI/CD pipeline, staging/production workflow, secret management               |
 | [Housing Behavior Reference](behavior.md) | Canonical housing lifecycle, edge-case matrix, and expected runtime behavior |
-| [Changelog](changelog.md) | Historical log of all major changes |
+| [Changelog](changelog.md)                 | Historical log of all major changes                                          |
 
 ## Specs
 
 Spec-driven development workflow and active specifications live in [`docs/spec/current/`](spec/current/). Completed specs are archived in [`docs/spec/archive/`](spec/archive/README.md).
 
-| Active Spec | Status |
-|---|---|
+| Active Spec                                                            | Status      |
+| ---------------------------------------------------------------------- | ----------- |
 | [Staging Environment Setup](spec/current/staging-environment-setup.md) | In Progress |
-| [Recurring Task Update Scopes](spec/current/recurring-task-update-scopes.md) | In Progress |
 
-| Archived Completed Spec | Location |
-|---|---|
-| Deploy Strategy Update | [docs/spec/archive/deploy-strategy-update.md](spec/archive/deploy-strategy-update.md) |
-| Discord Sync Automation | [docs/spec/archive/discord-sync-automation.md](spec/archive/discord-sync-automation.md) |
-| Centralize Env Config | [docs/spec/archive/centralize-env-config.md](spec/archive/centralize-env-config.md) |
-| Quality Gate Fixes | [docs/spec/archive/quality-gate-fixes.md](spec/archive/quality-gate-fixes.md) |
-| Infrastructure Logic Hardening | [docs/spec/archive/infra-logic-hardening.md](spec/archive/infra-logic-hardening.md) |
+| Archived Completed Spec        | Location                                                                                              |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Deploy Strategy Update         | [docs/spec/archive/deploy-strategy-update.md](spec/archive/deploy-strategy-update.md)                 |
+| Discord Sync Automation        | [docs/spec/archive/discord-sync-automation.md](spec/archive/discord-sync-automation.md)               |
+| Centralize Env Config          | [docs/spec/archive/centralize-env-config.md](spec/archive/centralize-env-config.md)                   |
+| Quality Gate Fixes             | [docs/spec/archive/quality-gate-fixes.md](spec/archive/quality-gate-fixes.md)                         |
+| Infrastructure Logic Hardening | [docs/spec/archive/infra-logic-hardening.md](spec/archive/infra-logic-hardening.md)                   |
 | QA Audit and Staging Hardening | [docs/spec/archive/qa-audit-and-staging-hardening.md](spec/archive/qa-audit-and-staging-hardening.md) |
+| Recurring Task Update Scopes   | [docs/spec/archive/recurring-task-update-scopes.md](spec/archive/recurring-task-update-scopes.md)     |
 
 > Rule of thumb: `docs/spec/current/` tracks planned/in-flight implementation work; `docs/` captures durable references; `docs/spec/archive/` stores completed specs.
 
 ## Style Guides
 
-| Guide | Description |
-|---|---|
-| [General](style-guide/general.md) | Cross-language principles |
+| Guide                                   | Description                     |
+| --------------------------------------- | ------------------------------- |
+| [General](style-guide/general.md)       | Cross-language principles       |
 | [TypeScript](style-guide/typescript.md) | TypeScript rules (Google style) |
 | [JavaScript](style-guide/javascript.md) | JavaScript rules (Google style) |
-| [HTML/CSS](style-guide/html-css.md) | Markup and styling rules |
+| [HTML/CSS](style-guide/html-css.md)     | Markup and styling rules        |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ Orchestrates business logic and use cases.
 
 - **Services**: `DutyService`, `LedgerService`, `LibraryService`, `ScheduleService`, `AdminService`.
 - **Event Handlers**: Asynchronous listeners for domain events (e.g., `JobCompletedEvent`).
-- **Scheduling**: Cron handlers (`lib/application/services/jobs`) for recurring logic — `UnlockTasksJob`, `NotifyUrgentJob`, `ExpireDutiesJob`, `EnsureFutureTasksJob`.
+- **Scheduling**: Cron handlers (`lib/application/services/jobs`) for recurring logic — `UnlockTasksJob`, `NotifyRecurringJob`, `NotifyUrgentJob`, `ExpireDutiesJob`, `NotifyExpiredJob`, `EnsureFutureTasksJob`.
 
 ### 3. Infrastructure Layer (`lib/infrastructure`)
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -61,6 +61,9 @@ This document is the durable behavioral reference for the Housing module.
 5. Admin approves -> `approved`.
 6. Next recurring instance is generated.
 7. If missed deadline, task transitions to `expired` and fine behavior is triggered.
+8. Overdue transition is canonicalized through shared expiry logic and may run from:
+   - cron (`ExpireDutiesJob`) as the primary scheduled path, and
+   - dashboard maintenance as a fallback path for assigned-user views.
 
 ## 3.2 One-Off Duty Flow
 
@@ -111,6 +114,7 @@ This document is the durable behavioral reference for the Housing module.
 - Allowed only for housing admins.
 - Should fail clearly if task is not found.
 - Historical audit concerns should be considered for already-approved records.
+- For recurring deletions using `this_and_future` or `entire_series`, the schedule is soft-deactivated (`active: false`) before future-row cleanup to prevent cron resurrection races.
 
 ### Claim / Unclaim
 
@@ -167,11 +171,15 @@ This document is the durable behavioral reference for the Housing module.
 - Recurrence generation should avoid creating overdue instances on recovery paths.
 - Expiry check must use consistent timezone assumptions.
 - Cron runs should be idempotent enough to avoid repeated destructive side effects.
+- `open` tasks whose due time has passed should not remain user-actionable in dashboard views; they must be transitioned to `expired` by canonical expiry logic or hidden until transition completes.
 
 ## 5.5 Notification Edge Cases
 
 - Notification delivery failure should not silently mark notification stage complete when retry is desired.
-- Critical dual-notification paths (admin channel + user DM) should only mark complete after required deliveries succeed.
+- Critical dual-notification paths (admin channel + user DM) should only mark complete after all required deliveries succeed.
+- Expired notifications require both channel and DM success before `notification_level` advances to `expired`.
+- Unlock and recurring notification stages should persist completion only after successful delivery.
+- Urgent reminder threshold is `12` hours before `due_at`.
 
 ## 6) Error Surface Expectations
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,6 +93,8 @@ What it verifies:
 - Discord guild reachability with bot token
 - Discord housing channel reachability
 - Configured housing role IDs exist in the target guild
+- Cron endpoint auth contract and HOURLY dispatch health (manual run path)
+- Housing expiry notification dependencies (`DISCORD_HOUSING_CHANNEL_ID`, bot DM capability)
 
 If this command fails, do not promote staging to production until the failing checks are resolved.
 

--- a/lib/application/services/housing/admin.service.test.ts
+++ b/lib/application/services/housing/admin.service.test.ts
@@ -263,5 +263,22 @@ describe("AdminService", () => {
       );
       expect(mockTaskRepo.delete).not.toHaveBeenCalled();
     });
+
+    it("routes delete to schedule service for this_and_future scope", async () => {
+      const task = {
+        id: "task-Z",
+        schedule_id: "schedule-Z",
+        due_at: "2026-03-10T03:59:00.000Z",
+      };
+      (mockTaskRepo.findById as any).mockResolvedValue(task);
+
+      await service.deleteTask("task-Z", { scope: "this_and_future" });
+
+      expect(mockScheduleService.deleteTaskThisAndFuture).toHaveBeenCalledWith(
+        task,
+        "2026-03-10T03:59:00.000Z",
+      );
+      expect(mockTaskRepo.delete).not.toHaveBeenCalled();
+    });
   });
 });

--- a/lib/application/services/housing/duty.service.ts
+++ b/lib/application/services/housing/duty.service.ts
@@ -181,8 +181,16 @@ export class DutyService implements IDutyService {
         continue;
       }
 
-      // If it looks expired but isn't updated yet, we hide it or show it as is.
-      // Ideally Maintenance runs BEFORE this, so the data is fresh.
+      // Defensive filter: never present overdue duty rows as actionable if
+      // maintenance/cron has not persisted the expired transition yet.
+      if (
+        task.status === "open" &&
+        task.due_at &&
+        new Date() > new Date(task.due_at) &&
+        !task.proof_s3_key
+      ) {
+        continue;
+      }
 
       filtered.push(task);
     }

--- a/lib/application/services/housing/maintenance.service.ts
+++ b/lib/application/services/housing/maintenance.service.ts
@@ -7,13 +7,16 @@
 
 import { ITaskRepository } from "@/lib/domain/ports/task.repository";
 import { IDutyService } from "@/lib/domain/ports/services/duty.service.port";
-import { DomainEventBus } from "@/lib/infrastructure/events/dispatcher";
-import { TaskEvents } from "@/lib/domain/events";
+import { IPointsService } from "@/lib/domain/ports/services/points.service.port";
+import { ScheduleService } from "./schedule.service";
+import { expireOverdueDutyTask } from "./overdue-duty.service";
 
 export class MaintenanceService {
   constructor(
     private readonly taskRepository: ITaskRepository,
     private readonly dutyService: IDutyService,
+    private readonly pointsService: IPointsService,
+    private readonly scheduleService: ScheduleService,
   ) {}
 
   /**
@@ -58,19 +61,37 @@ export class MaintenanceService {
             now > new Date(task.due_at) &&
             !task.proof_s3_key
           ) {
-            // IT IS EXPIRED
-            await this.taskRepository.update(task.id, {
-              status: "expired",
+            const result = await expireOverdueDutyTask(task, {
+              taskRepository: this.taskRepository,
+              pointsService: this.pointsService,
+              scheduleService: this.scheduleService,
             });
-
-            // Emit Event
-            await DomainEventBus.publish(TaskEvents.TASK_EXPIRED, {
-              taskId: task.id,
-              title: task.title,
-              userId: userId,
-              fineAmount: 50,
-            });
-            return;
+            if (result.errors.length > 0) {
+              console.error("[MaintenanceService] Overdue processing errors", {
+                taskId: task.id,
+                scheduleId: task.schedule_id ?? null,
+                errors: result.errors,
+              });
+            }
+            if (result.expired) {
+              console.log("[MaintenanceService]", {
+                phase: "task_expired",
+                taskId: task.id,
+                scheduleId: task.schedule_id ?? null,
+                fined: result.fined,
+                triggeredNextInstance: result.triggeredNextInstance,
+              });
+            } else {
+              console.log("[MaintenanceService]", {
+                phase: "task_expire_skipped",
+                taskId: task.id,
+                type: task.type,
+                status: task.status,
+              });
+            }
+            if (result.expired) {
+              return;
+            }
           }
 
           // Check D: Open Bounty but Expired (Assigned)

--- a/lib/application/services/housing/overdue-duty.service.ts
+++ b/lib/application/services/housing/overdue-duty.service.ts
@@ -1,0 +1,100 @@
+import { HOUSING_CONSTANTS } from "@/lib/constants";
+import { HousingTask } from "@/lib/domain/types/task";
+import { ITaskRepository } from "@/lib/domain/ports/task.repository";
+import { IPointsService } from "@/lib/domain/ports/services/points.service.port";
+import { ScheduleService } from "./schedule.service";
+
+type OverdueDutyDependencies = {
+  taskRepository: ITaskRepository;
+  pointsService: IPointsService;
+  scheduleService: ScheduleService;
+};
+
+type OverdueDutyResult = {
+  expired: boolean;
+  fined: boolean;
+  triggeredNextInstance: boolean;
+  errors: string[];
+};
+
+const NON_EXPIRABLE_TYPES: HousingTask["type"][] = [
+  "bounty",
+  "project",
+  "ad_hoc",
+];
+
+/**
+ * Expires a single overdue duty-like task and applies all required side effects.
+ * This centralizes behavior so cron and maintenance stay consistent.
+ */
+export async function expireOverdueDutyTask(
+  task: HousingTask,
+  dependencies: OverdueDutyDependencies,
+): Promise<OverdueDutyResult> {
+  const { taskRepository, pointsService, scheduleService } = dependencies;
+  const errors: string[] = [];
+
+  if (NON_EXPIRABLE_TYPES.includes(task.type)) {
+    return {
+      expired: false,
+      fined: false,
+      triggeredNextInstance: false,
+      errors,
+    };
+  }
+
+  if (!task.due_at || new Date(task.due_at) > new Date()) {
+    return {
+      expired: false,
+      fined: false,
+      triggeredNextInstance: false,
+      errors,
+    };
+  }
+
+  if (task.proof_s3_key) {
+    return {
+      expired: false,
+      fined: false,
+      triggeredNextInstance: false,
+      errors,
+    };
+  }
+
+  await taskRepository.update(task.id, {
+    status: "expired",
+  });
+
+  let fined = false;
+  if (task.assigned_to) {
+    try {
+      await pointsService.awardPoints(task.assigned_to, {
+        amount: -Math.abs(HOUSING_CONSTANTS.FINE_MISSING_DUTY),
+        reason: `Missed Duty: ${task.title}`,
+        category: "fine",
+      });
+      fined = true;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`Fine failed for ${task.id}: ${message}`);
+    }
+  }
+
+  let triggeredNextInstance = false;
+  if (task.schedule_id) {
+    try {
+      await scheduleService.triggerNextInstance(task.schedule_id, task);
+      triggeredNextInstance = true;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`Scheduler failed for ${task.id}: ${message}`);
+    }
+  }
+
+  return {
+    expired: true,
+    fined,
+    triggeredNextInstance,
+    errors,
+  };
+}

--- a/lib/application/services/housing/query.service.ts
+++ b/lib/application/services/housing/query.service.ts
@@ -23,11 +23,21 @@ export class QueryService {
   }
 
   async getAllActiveTasks() {
-    return await this.taskRepository.findMany({
+    const tasks = await this.taskRepository.findMany({
       status: ["open", "pending", "locked", "rejected"],
       orderBy: "createdAt",
       orderDirection: "desc",
       limit: 100, // Reasonable limit for now
+    });
+
+    const now = new Date();
+    return tasks.filter((task) => {
+      const isOverdueOpenWithoutProof =
+        task.status === "open" &&
+        !!task.due_at &&
+        now > new Date(task.due_at) &&
+        !task.proof_s3_key;
+      return !isOverdueOpenWithoutProof;
     });
   }
 

--- a/lib/application/services/housing/schedule.service.test.ts
+++ b/lib/application/services/housing/schedule.service.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScheduleService } from "./schedule.service";
+import { MockFactory } from "@/lib/test/mock-factory";
+
+describe("ScheduleService deleteTaskThisAndFuture", () => {
+  const taskRepository = MockFactory.createTaskRepository();
+  const service = new ScheduleService(taskRepository);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deactivates schedule before deleting rows to avoid cron resurrection", async () => {
+    const task = {
+      id: "task-1",
+      schedule_id: "schedule-1",
+      due_at: "2026-03-10T03:59:00.000Z",
+    } as any;
+
+    taskRepository.findScheduleById = vi.fn().mockResolvedValue({
+      id: "schedule-1",
+      active: true,
+    } as any);
+    taskRepository.updateSchedule = vi.fn().mockResolvedValue({} as any);
+    taskRepository.findMany = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: "task-1",
+          due_at: "2026-03-10T03:59:00.000Z",
+          status: "open",
+        },
+        {
+          id: "task-2",
+          due_at: "2026-03-17T03:59:00.000Z",
+          status: "open",
+        },
+      ] as any)
+      .mockResolvedValueOnce([] as any);
+    taskRepository.delete = vi.fn().mockResolvedValue(undefined);
+
+    await service.deleteTaskThisAndFuture(task, "2026-03-10T03:59:00.000Z");
+
+    expect(taskRepository.updateSchedule).toHaveBeenCalledWith("schedule-1", {
+      active: false,
+      last_generated_at: expect.any(String),
+    });
+    expect(taskRepository.delete).toHaveBeenCalledWith("task-1");
+    expect(taskRepository.delete).toHaveBeenCalledWith("task-2");
+
+    const updateScheduleOrder = (taskRepository.updateSchedule as any).mock
+      .invocationCallOrder[0];
+    const firstDeleteOrder = (taskRepository.delete as any).mock
+      .invocationCallOrder[0];
+    expect(updateScheduleOrder).toBeLessThan(firstDeleteOrder);
+  });
+});

--- a/lib/application/services/housing/schedule.service.ts
+++ b/lib/application/services/housing/schedule.service.ts
@@ -617,6 +617,16 @@ export class ScheduleService {
       return;
     }
 
+    const schedule = await this.taskRepository.findScheduleById(
+      task.schedule_id,
+    );
+    if (schedule?.active) {
+      await this.taskRepository.updateSchedule(task.schedule_id, {
+        active: false,
+        last_generated_at: new Date().toISOString(),
+      });
+    }
+
     const effectiveFrom = new Date(effectiveFromDueAt);
     const seriesTasks = await this.findAllNonFinalByScheduleId(
       task.schedule_id,
@@ -641,13 +651,14 @@ export class ScheduleService {
       (result) => result.status === "rejected",
     );
     if (deleteFailure && deleteFailure.status === "rejected") {
-      throw deleteFailure.reason;
+      const message =
+        deleteFailure.reason instanceof Error
+          ? deleteFailure.reason.message
+          : String(deleteFailure.reason);
+      throw new Error(
+        `Series deactivated but one or more task rows failed to delete: ${message}`,
+      );
     }
-
-    await this.taskRepository.updateSchedule(task.schedule_id, {
-      active: false,
-      last_generated_at: new Date().toISOString(),
-    });
   }
 
   /**

--- a/lib/application/services/jobs/cron.service.test.ts
+++ b/lib/application/services/jobs/cron.service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  return {
+    taskRepository: {},
+    unlockRun: vi.fn(),
+    recurringRun: vi.fn(),
+    urgentRun: vi.fn(),
+    expireRun: vi.fn(),
+    notifyExpiredRun: vi.fn(),
+    ensureFutureRun: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/infrastructure/container", () => ({
+  getContainer: () => ({
+    taskRepository: hoisted.taskRepository,
+  }),
+}));
+
+vi.mock("./handlers/unlock-tasks.job", () => ({
+  UnlockTasksJob: { run: hoisted.unlockRun },
+}));
+
+vi.mock("./handlers/notify-recurring.job", () => ({
+  NotifyRecurringJob: { run: hoisted.recurringRun },
+}));
+
+vi.mock("./handlers/notify-urgent.job", () => ({
+  NotifyUrgentJob: { run: hoisted.urgentRun },
+}));
+
+vi.mock("./handlers/expire-duties.job", () => ({
+  expireDutiesJob: hoisted.expireRun,
+}));
+
+vi.mock("./handlers/notify-expired.job", () => ({
+  NotifyExpiredJob: { run: hoisted.notifyExpiredRun },
+}));
+
+vi.mock("./handlers/ensure-future-tasks.job", () => ({
+  ensureFutureTasksJob: hoisted.ensureFutureRun,
+}));
+
+import { CronService } from "./cron.service";
+
+describe("CronService.runHourly", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.unlockRun.mockResolvedValue({ unlocked: 1, errors: [] });
+    hoisted.recurringRun.mockResolvedValue({ notified: 1, errors: [] });
+    hoisted.urgentRun.mockResolvedValue({ urgent: 1, errors: [] });
+    hoisted.expireRun.mockResolvedValue({ errors: [] });
+    hoisted.notifyExpiredRun.mockResolvedValue({
+      expired_notified: 1,
+      skipped_unassigned: 0,
+      errors: [],
+    });
+    hoisted.ensureFutureRun.mockResolvedValue(undefined);
+  });
+
+  it("runs hourly pipeline in order and returns aggregated stats", async () => {
+    const result = await CronService.runHourly();
+
+    expect(result).toEqual({
+      unlocked: 2,
+      urgent: 1,
+      expired_notified: 1,
+      skipped_unassigned: 0,
+      errors: [],
+    });
+    expect(hoisted.unlockRun).toHaveBeenCalledWith(hoisted.taskRepository);
+    expect(hoisted.recurringRun).toHaveBeenCalledWith(hoisted.taskRepository);
+    expect(hoisted.urgentRun).toHaveBeenCalledWith(hoisted.taskRepository);
+    expect(hoisted.notifyExpiredRun).toHaveBeenCalledWith(
+      hoisted.taskRepository,
+    );
+    expect(hoisted.ensureFutureRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/application/services/jobs/cron.service.ts
+++ b/lib/application/services/jobs/cron.service.ts
@@ -27,7 +27,11 @@ export const CronService = {
    * Orchestrates the execution of all hourly tasks.
    */
   async runHourly() {
-    console.log("🚀 Starting Cron Job...");
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "start",
+      startedAt: new Date().toISOString(),
+    });
     const { taskRepository } = getContainer();
 
     // Aggregated Stats
@@ -41,39 +45,73 @@ export const CronService = {
     const unlockResult = await UnlockTasksJob.run(taskRepository);
     unlocked += unlockResult.unlocked;
     errors.push(...unlockResult.errors);
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "unlock_complete",
+      unlocked: unlockResult.unlocked,
+      errors: unlockResult.errors.length,
+    });
 
     // 2. Notify Recurring
     const recurringResult = await NotifyRecurringJob.run(taskRepository);
     unlocked += recurringResult.notified;
     errors.push(...recurringResult.errors);
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "notify_recurring_complete",
+      notified: recurringResult.notified,
+      errors: recurringResult.errors.length,
+    });
 
     // 3. Notify Urgent
     const urgentResult = await NotifyUrgentJob.run(taskRepository);
     urgent += urgentResult.urgent;
     errors.push(...urgentResult.errors);
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "notify_urgent_complete",
+      urgent: urgentResult.urgent,
+      errors: urgentResult.errors.length,
+    });
 
     // 4. Expire Duties (Self-Contained)
     const expireResult = await expireDutiesJob();
     errors.push(...expireResult.errors);
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "expire_duties_complete",
+      errors: expireResult.errors.length,
+    });
 
     // 5. Notify Expired
     const notifyExpiredResult = await NotifyExpiredJob.run(taskRepository);
     expired_notified += notifyExpiredResult.expired_notified;
     skipped_unassigned += notifyExpiredResult.skipped_unassigned;
     errors.push(...notifyExpiredResult.errors);
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "notify_expired_complete",
+      expiredNotified: notifyExpiredResult.expired_notified,
+      skippedUnassigned: notifyExpiredResult.skipped_unassigned,
+      errors: notifyExpiredResult.errors.length,
+    });
 
     // 6. Ensure Future Tasks (Self-Healing)
     await ensureFutureTasksJob();
 
     // Summary
-    const stats = {
+    const stats: CronResult = {
       unlocked,
       urgent,
       expired_notified,
       skipped_unassigned,
       errors,
     };
-    console.log("📊 Cron Summary:", stats);
+    console.log("[CronService]", {
+      job: "HOURLY",
+      phase: "completed",
+      ...stats,
+    });
     if (errors.length > 0) {
       console.error("⚠️ Cron Errors:", errors);
     }

--- a/lib/application/services/jobs/handlers/expire-duties.job.test.ts
+++ b/lib/application/services/jobs/handlers/expire-duties.job.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  return {
+    taskRepository: {
+      findMany: vi.fn(),
+    },
+    pointsService: {},
+    scheduleService: {},
+    expireOverdueDutyTask: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/infrastructure/container", () => ({
+  getContainer: () => ({
+    taskRepository: hoisted.taskRepository,
+    pointsService: hoisted.pointsService,
+    scheduleService: hoisted.scheduleService,
+  }),
+}));
+
+vi.mock("@/lib/application/services/housing/overdue-duty.service", () => ({
+  expireOverdueDutyTask: hoisted.expireOverdueDutyTask,
+}));
+
+import { expireDutiesJob } from "./expire-duties.job";
+
+describe("expireDutiesJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("processes overdue open tasks through shared overdue processor", async () => {
+    hoisted.taskRepository.findMany.mockResolvedValue([
+      {
+        id: "task-1",
+        title: "Kitchen",
+        status: "open",
+        due_at: new Date(Date.now() - 60_000).toISOString(),
+      },
+      {
+        id: "task-2",
+        title: "Future",
+        status: "open",
+        due_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+    ]);
+    hoisted.expireOverdueDutyTask.mockResolvedValue({
+      expired: true,
+      fined: true,
+      triggeredNextInstance: true,
+      errors: [],
+    });
+
+    const result = await expireDutiesJob();
+
+    expect(result.errors).toEqual([]);
+    expect(hoisted.expireOverdueDutyTask).toHaveBeenCalledTimes(1);
+    expect(hoisted.expireOverdueDutyTask).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "task-1" }),
+      expect.objectContaining({
+        taskRepository: hoisted.taskRepository,
+      }),
+    );
+  });
+});

--- a/lib/application/services/jobs/handlers/expire-duties.job.ts
+++ b/lib/application/services/jobs/handlers/expire-duties.job.ts
@@ -1,31 +1,18 @@
-import { AppwriteTaskRepository } from "@/lib/infrastructure/persistence/task.repository";
-import { PointsService } from "@/lib/application/services/ledger/points.service";
-import { ScheduleService } from "@/lib/application/services/housing/schedule.service";
-import { AppwriteLedgerRepository } from "@/lib/infrastructure/persistence/ledger.repository";
-import { AppwriteUserRepository } from "@/lib/infrastructure/persistence/user.repository";
-import { HOUSING_CONSTANTS } from "@/lib/constants";
-
-// Helper to construct services (DI Container Lite)
-function getServices() {
-  const taskRepo = new AppwriteTaskRepository();
-  const ledgerRepo = new AppwriteLedgerRepository();
-  const userRepo = new AppwriteUserRepository();
-
-  const pointsService = new PointsService(userRepo, ledgerRepo);
-  const scheduleService = new ScheduleService(taskRepo);
-
-  return { taskRepo, pointsService, scheduleService };
-}
+import { getContainer } from "@/lib/infrastructure/container";
+import { expireOverdueDutyTask } from "@/lib/application/services/housing/overdue-duty.service";
 
 export const expireDutiesJob = async (): Promise<{ errors: string[] }> => {
-  const { taskRepo, pointsService, scheduleService } = getServices();
+  const { taskRepository, pointsService, scheduleService } = getContainer();
   const errors: string[] = [];
   const now = new Date();
 
-  console.log("⏰ Running ExpireDutiesJob...");
+  console.log("[ExpireDutiesJob]", {
+    phase: "start",
+    now: now.toISOString(),
+  });
 
   try {
-    const allOpenTasks = await taskRepo.findMany({
+    const allOpenTasks = await taskRepository.findMany({
       status: "open",
       limit: 100,
     });
@@ -36,46 +23,28 @@ export const expireDutiesJob = async (): Promise<{ errors: string[] }> => {
       return new Date(task.due_at) <= now;
     });
 
-    console.log(`   Found ${overdueTasks.length} overdue tasks.`);
+    console.log("[ExpireDutiesJob]", {
+      phase: "overdue_scan_complete",
+      overdueCount: overdueTasks.length,
+    });
 
     for (const task of overdueTasks) {
       try {
-        if (task.type === "bounty" || task.type === "project") continue;
-
-        console.log(`   Expiring task: "${task.title}" (ID: ${task.id})`);
-
-        await taskRepo.update(task.id, {
-          status: "expired",
+        const result = await expireOverdueDutyTask(task, {
+          taskRepository,
+          pointsService,
+          scheduleService,
         });
-
-        if (task.assigned_to) {
-          try {
-            await pointsService.awardPoints(task.assigned_to, {
-              amount: -Math.abs(HOUSING_CONSTANTS.FINE_MISSING_DUTY),
-              reason: `Missed Duty: ${task.title}`,
-              category: "fine",
-            });
-          } catch (e) {
-            console.error(`   Failed to fine user for ${task.id}`, e);
-          }
-        }
-
-        if (task.schedule_id) {
-          try {
-            await scheduleService.triggerNextInstance(task.schedule_id, task);
-            console.log(
-              `   Triggered next instance for schedule ${task.schedule_id}`,
-            );
-          } catch (e) {
-            // CRITICAL: If this fails, the recurrence chain breaks.
-            console.error(
-              `🚨 CRITICAL SCHEDULER ERROR: Failed to trigger next instance for expired task ${task.id} (Schedule: ${task.schedule_id})`,
-              e,
-            );
-            errors.push(
-              `Scheduler Failed for ${task.id}: ${e instanceof Error ? e.message : String(e)}`,
-            );
-          }
+        errors.push(...result.errors);
+        if (result.expired) {
+          console.log("[ExpireDutiesJob]", {
+            phase: "task_expired",
+            taskId: task.id,
+            scheduleId: task.schedule_id ?? null,
+            fined: result.fined,
+            triggeredNextInstance: result.triggeredNextInstance,
+            errorCount: result.errors.length,
+          });
         }
       } catch (error: unknown) {
         const errMsg = `Failed to expire task ${task.id}: ${error instanceof Error ? error.message : String(error)}`;

--- a/lib/application/services/jobs/handlers/notify-expired.job.test.ts
+++ b/lib/application/services/jobs/handlers/notify-expired.job.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotifyExpiredJob } from "./notify-expired.job";
+import { NotificationService } from "@/lib/application/services/shared/notification.service";
+import { MockFactory } from "@/lib/test/mock-factory";
+
+describe("NotifyExpiredJob", () => {
+  const taskRepository = MockFactory.createTaskRepository();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks expired notification only when channel and DM both succeed", async () => {
+    taskRepository.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "task-1",
+        title: "Kitchen",
+        type: "duty",
+        status: "expired",
+        notification_level: "urgent",
+        assigned_to: "user-1",
+      },
+    ] as any);
+    taskRepository.update = vi.fn().mockResolvedValue({} as any);
+    vi.spyOn(NotificationService, "notifyAdmins").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(NotificationService, "sendNotification").mockResolvedValue({
+      success: true,
+    });
+
+    const result = await NotifyExpiredJob.run(taskRepository);
+
+    expect(result.expired_notified).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(taskRepository.update).toHaveBeenCalledWith("task-1", {
+      notification_level: "expired",
+    });
+  });
+
+  it("does not send DM or mark complete when channel fails", async () => {
+    taskRepository.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "task-2",
+        title: "Bathroom",
+        type: "duty",
+        status: "expired",
+        notification_level: "urgent",
+        assigned_to: "user-2",
+      },
+    ] as any);
+    taskRepository.update = vi.fn().mockResolvedValue({} as any);
+    vi.spyOn(NotificationService, "notifyAdmins").mockResolvedValue({
+      success: false,
+      error: "channel missing",
+    });
+    const dmSpy = vi
+      .spyOn(NotificationService, "sendNotification")
+      .mockResolvedValue({ success: true });
+
+    const result = await NotifyExpiredJob.run(taskRepository);
+
+    expect(result.expired_notified).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(dmSpy).not.toHaveBeenCalled();
+    expect(taskRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/lib/application/services/jobs/handlers/notify-expired.job.ts
+++ b/lib/application/services/jobs/handlers/notify-expired.job.ts
@@ -2,9 +2,7 @@ import { ITaskRepository } from "@/lib/domain/ports/task.repository";
 import { NotificationService } from "@/lib/application/services/shared/notification.service";
 
 export const NotifyExpiredJob = {
-  async run(
-    taskRepository: ITaskRepository,
-  ): Promise<{
+  async run(taskRepository: ITaskRepository): Promise<{
     expired_notified: number;
     skipped_unassigned: number;
     errors: string[];
@@ -24,9 +22,10 @@ export const NotifyExpiredJob = {
         (task) => task.notification_level !== "expired",
       );
 
-      console.log(
-        `📢 Found ${tasksToNotify.length} expired tasks needing notification`,
-      );
+      console.log("[NotifyExpiredJob]", {
+        phase: "expired_scan_complete",
+        expiredToNotify: tasksToNotify.length,
+      });
 
       for (const task of tasksToNotify) {
         try {
@@ -53,6 +52,9 @@ export const NotifyExpiredJob = {
             const errMsg = `Channel notification failed for task ${task.id}: ${channelResult.error}`;
             console.error(`[NotifyExpiredJob] ${errMsg}`);
             errors.push(errMsg);
+            // Dual-delivery behavior: do not notify user or advance stage
+            // until the channel path succeeds.
+            continue;
           }
 
           // 2. Notify User (DM) - Critical
@@ -72,11 +74,16 @@ export const NotifyExpiredJob = {
             continue; // Skip DB update — retry next run
           }
 
-          // 3. Mark as Notified only if DM succeeded
+          // 3. Mark as Notified only if BOTH channel and DM succeeded
           await taskRepository.update(task.id, {
             notification_level: "expired",
           });
 
+          console.log("[NotifyExpiredJob]", {
+            phase: "expired_notified",
+            taskId: task.id,
+            assignee: task.assigned_to,
+          });
           expired_notified++;
         } catch (error: unknown) {
           const errMsg = `Failed to notify expired task ${task.id}: ${error instanceof Error ? error.message : String(error)}`;

--- a/lib/application/services/jobs/handlers/notify-recurring.job.test.ts
+++ b/lib/application/services/jobs/handlers/notify-recurring.job.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NotifyRecurringJob } from "./notify-recurring.job";
+import { NotificationService } from "@/lib/application/services/shared/notification.service";
+import { MockFactory } from "@/lib/test/mock-factory";
+
+describe("NotifyRecurringJob", () => {
+  const taskRepository = MockFactory.createTaskRepository();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates notification level only after successful DM", async () => {
+    taskRepository.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "task-1",
+        title: "Kitchen",
+        status: "open",
+        schedule_id: "schedule-1",
+        notification_level: "none",
+        assigned_to: "user-1",
+      },
+    ] as any);
+    taskRepository.update = vi.fn().mockResolvedValue({} as any);
+    vi.spyOn(NotificationService, "sendNotification").mockResolvedValue({
+      success: true,
+    });
+
+    const result = await NotifyRecurringJob.run(taskRepository);
+
+    expect(result.notified).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(taskRepository.update).toHaveBeenCalledWith("task-1", {
+      notification_level: "unlocked",
+    });
+  });
+
+  it("does not advance stage when DM fails", async () => {
+    taskRepository.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "task-2",
+        title: "Hallway",
+        status: "open",
+        schedule_id: "schedule-2",
+        notification_level: "none",
+        assigned_to: "user-2",
+      },
+    ] as any);
+    taskRepository.update = vi.fn().mockResolvedValue({} as any);
+    vi.spyOn(NotificationService, "sendNotification").mockResolvedValue({
+      success: false,
+      error: "timeout",
+    });
+
+    const result = await NotifyRecurringJob.run(taskRepository);
+
+    expect(result.notified).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(taskRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/lib/application/services/jobs/handlers/notify-recurring.job.ts
+++ b/lib/application/services/jobs/handlers/notify-recurring.job.ts
@@ -19,19 +19,16 @@ export const NotifyRecurringJob = {
         (task) => task.notification_level === "none" && task.schedule_id,
       );
 
-      console.log(
-        `📬 Found ${uninformedRecurring.length} uninformed recurring tasks`,
-      );
+      console.log("[NotifyRecurringJob]", {
+        phase: "recurring_scan_complete",
+        uninformedRecurring: uninformedRecurring.length,
+      });
 
       for (const task of uninformedRecurring) {
         try {
           if (!task.assigned_to) continue;
 
-          await taskRepository.update(task.id, {
-            notification_level: "unlocked",
-          });
-
-          await NotificationService.sendNotification(
+          const notificationResult = await NotificationService.sendNotification(
             task.assigned_to,
             "unlocked",
             {
@@ -39,6 +36,25 @@ export const NotifyRecurringJob = {
               taskId: task.id,
             },
           );
+          if (!notificationResult.success) {
+            const errMsg = `Recurring notification failed for task ${task.id}: ${notificationResult.error}`;
+            errors.push(errMsg);
+            console.error("[NotifyRecurringJob]", {
+              phase: "recurring_notification_failed",
+              taskId: task.id,
+              error: notificationResult.error,
+            });
+            continue;
+          }
+          await taskRepository.update(task.id, {
+            notification_level: "unlocked",
+          });
+
+          console.log("[NotifyRecurringJob]", {
+            phase: "recurring_notified",
+            taskId: task.id,
+            assignee: task.assigned_to,
+          });
           notified++;
         } catch (error: unknown) {
           const errMsg = `Failed to notify recurring task ${task.id}: ${error instanceof Error ? error.message : String(error)}`;

--- a/lib/application/services/jobs/handlers/unlock-tasks.job.test.ts
+++ b/lib/application/services/jobs/handlers/unlock-tasks.job.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { UnlockTasksJob } from "./unlock-tasks.job";
+import { NotificationService } from "@/lib/application/services/shared/notification.service";
+import { MockFactory } from "@/lib/test/mock-factory";
+
+describe("UnlockTasksJob", () => {
+  const taskRepository = MockFactory.createTaskRepository();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens task and marks unlocked when DM succeeds", async () => {
+    taskRepository.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "task-1",
+        title: "Kitchen",
+        status: "locked",
+        unlock_at: new Date(Date.now() - 60_000).toISOString(),
+        assigned_to: "user-1",
+      },
+    ] as any);
+    taskRepository.update = vi.fn().mockResolvedValue({} as any);
+    vi.spyOn(NotificationService, "sendNotification").mockResolvedValue({
+      success: true,
+    });
+
+    const result = await UnlockTasksJob.run(taskRepository);
+
+    expect(result.errors).toEqual([]);
+    expect(result.unlocked).toBe(1);
+    expect(taskRepository.update).toHaveBeenNthCalledWith(1, "task-1", {
+      status: "open",
+      notification_level: "none",
+    });
+    expect(taskRepository.update).toHaveBeenNthCalledWith(2, "task-1", {
+      notification_level: "unlocked",
+    });
+  });
+
+  it("keeps notification level retryable when DM fails", async () => {
+    taskRepository.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "task-2",
+        title: "Bathroom",
+        status: "locked",
+        unlock_at: new Date(Date.now() - 60_000).toISOString(),
+        assigned_to: "user-2",
+      },
+    ] as any);
+    taskRepository.update = vi.fn().mockResolvedValue({} as any);
+    vi.spyOn(NotificationService, "sendNotification").mockResolvedValue({
+      success: false,
+      error: "discord down",
+    });
+
+    const result = await UnlockTasksJob.run(taskRepository);
+
+    expect(result.unlocked).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(taskRepository.update).toHaveBeenCalledTimes(1);
+    expect(taskRepository.update).toHaveBeenCalledWith("task-2", {
+      status: "open",
+      notification_level: "none",
+    });
+  });
+});

--- a/lib/application/services/jobs/handlers/unlock-tasks.job.ts
+++ b/lib/application/services/jobs/handlers/unlock-tasks.job.ts
@@ -20,25 +20,48 @@ export const UnlockTasksJob = {
         (task) => task.unlock_at && new Date(task.unlock_at) <= now,
       );
 
-      console.log(`🔓 Found ${tasksToUnlock.length} locked tasks to unlock`);
+      console.log("[UnlockTasksJob]", {
+        phase: "unlock_scan_complete",
+        toUnlock: tasksToUnlock.length,
+      });
 
       for (const task of tasksToUnlock) {
         try {
           await taskRepository.update(task.id, {
             status: "open",
-            notification_level: "unlocked",
+            notification_level: "none",
           });
 
           if (task.assigned_to) {
-            await NotificationService.sendNotification(
-              task.assigned_to,
-              "unlocked",
-              {
-                title: task.title,
+            const notificationResult =
+              await NotificationService.sendNotification(
+                task.assigned_to,
+                "unlocked",
+                {
+                  title: task.title,
+                  taskId: task.id,
+                },
+              );
+            if (!notificationResult.success) {
+              const errMsg = `Unlock notification failed for task ${task.id}: ${notificationResult.error}`;
+              errors.push(errMsg);
+              console.error("[UnlockTasksJob]", {
+                phase: "unlock_notification_failed",
                 taskId: task.id,
-              },
-            );
+                error: notificationResult.error,
+              });
+              continue;
+            }
+            await taskRepository.update(task.id, {
+              notification_level: "unlocked",
+            });
           }
+
+          console.log("[UnlockTasksJob]", {
+            phase: "task_unlocked",
+            taskId: task.id,
+            assignedTo: task.assigned_to ?? null,
+          });
           unlocked++;
         } catch (error: unknown) {
           const errMsg = `Failed to unlock task ${task.id}: ${error instanceof Error ? error.message : String(error)}`;

--- a/lib/infrastructure/container.ts
+++ b/lib/infrastructure/container.ts
@@ -94,6 +94,8 @@ export function getContainer(): Container {
     const maintenanceService = new MaintenanceService(
       taskRepository,
       dutyService,
+      pointsService,
+      scheduleService,
     );
     const adminService = new AdminService(taskRepository, scheduleService);
     const libraryService = new LibraryService(

--- a/lib/presentation/actions/housing/admin.actions.test.ts
+++ b/lib/presentation/actions/housing/admin.actions.test.ts
@@ -139,6 +139,22 @@ describe("housing admin actions", () => {
     );
   });
 
+  it("surfaces scoped delete failures from admin service", async () => {
+    hoisted.mockContainer.adminService.deleteTask.mockRejectedValue(
+      new Error(
+        "Series deactivated but one or more task rows failed to delete",
+      ),
+    );
+
+    const result = await deleteTaskAction("task-1", "jwt-token", {
+      scope: "this_and_future",
+      effectiveFromDueAt: "2026-03-10T03:59:00.000Z",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Series deactivated");
+  });
+
   it("passes acting user id to verifyTask on approve", async () => {
     await approveTaskAction("task-1", "jwt-token", 25);
 


### PR DESCRIPTION
## Summary
Implements housing cron/recurrence stabilization: shared overdue duty expiry (cron + maintenance), recurring delete ordering (deactivate schedule before row deletes), notification send-then-persist for unlock/recurring, dual-delivery for expired (channel + DM), dashboard/query filtering for overdue-open limbo, structured cron logs, and docs alignment.

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test -- --run lib/application/services/housing lib/application/services/jobs app/api/cron/route.test.ts`
- `SKIP_ENV_VALIDATION=true npm run build`

Note: Full `vitest --run` suite has pre-existing failures in env/combobox tests unrelated to this PR; housing/jobs area passes.

## Docs
- behavior.md, architecture.md, README spec index, deployment.md updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of overdue tasks to ensure they're properly transitioned to expired status and hidden from dashboard views
  * Enhanced task deletion feedback with specific messages for recurring task series modifications
  * Strengthened notification delivery requirements to ensure reliable message sending across multiple channels

* **Improvements**
  * Better error handling and logging for scheduled maintenance operations
  * More robust task expiry logic with improved fallback mechanisms

* **Documentation**
  * Updated deployment verification checklist for notification prerequisites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->