### PR TITLE
docs(housing): reconcile behavior with staging pipeline and fines

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -62,18 +62,28 @@ This document is the durable behavioral reference for the Housing module.
 5. Admin approves -> `approved`.
 6. Next recurring instance is generated.
 7. If missed deadline, task transitions to `expired` and fine behavior is triggered.
+   - For assigned mandatory duties, `expireOverdueDutyTask` sets `status: expired` and calls `PointsService.awardPoints` with a negative amount, `category: "fine"`, and `reason: Missed Duty: <task title>` (plain string; no embedded task id). There is **no** separate hourly “pending fines” job and **no** `[task:<id>]` ledger marker or `fineTaskId` flow in the current tree.
 8. Overdue transition is canonicalized through shared expiry logic and may run from:
-   - cron (`ExpireDutiesJob`) as the primary scheduled path, and
+   - cron (`expireDutiesJob`) as the primary scheduled path, and
    - dashboard maintenance as a fallback path for assigned-user views.
 
 ### Hourly pipeline: overdue duties, fines, and ledger
 
-The ordered hourly sequence lives in `HousingTimeDrivenPipeline` (see `lib/application/services/jobs/housing-time-driven.pipeline.ts`). **Expire overdue duties** is step 4 and must run **before** **Notify expired** (step 5): the task row is moved to `expired` first, then notification stages run.
+The ordered hourly sequence is implemented in `HousingTimeDrivenPipeline.runFullHourlyCycle` (`lib/application/services/jobs/housing-time-driven.pipeline.ts`):
 
-- **What “expire” does** (`expireDutiesJob` → `expireOverdueDutyTask`): picks mandatory work that is overdue (`open` or `pending` without `proof_s3_key`), sets `status: expired`, applies the configured **fine** in the same step via `PointsService.awardPoints` (negative amount, `category: "fine"`, `reason` of the form `Missed Duty: <title>`), and for schedule-backed duties calls `triggerNextInstance` so the next instance is not left to a separate code path.
+1. **Unlock** (`UnlockTasksJob`)
+2. **Recurring notify** (`NotifyRecurringJob`)
+3. **Urgent notify** (`NotifyUrgentJob`)
+4. **Expire overdue duties** (`expireDutiesJob` → `expireOverdueDutyTask` per eligible row) — must run **before** expired notifications so tasks are `expired` first
+5. **Notify expired** (`NotifyExpiredJob`)
+6. **Ensure future tasks** (`ensureFutureTasksJob`)
+
+There is **no** additional step after step 4 beyond notify-then-ensure-future; do not assume a fine-retry pass in the hourly cycle.
+
+- **What “expire” does** (`expireDutiesJob` → `expireOverdueDutyTask`): loads overdue mandatory work (`open` or `pending` without `proof_s3_key`), sets `status: expired`, attempts the missed-duty fine via `awardPoints`, and for schedule-backed duties calls `triggerNextInstance`.
 - **Domain events**: expiry does **not** publish a `TaskEvents` message; downstream work is synchronous in the pipeline and maintenance. That avoids dead “event-driven” handlers and duplicate `triggerNextInstance` calls.
-- **Task metadata**: the assignment schema includes optional `is_fine` on persisted tasks (`HousingTask` / app types) when the product marks fine-bearing rows; ledger entries remain the authoritative record of debits (`amount` positive with `is_debit: true` per `PointsService`).
-- **Idempotency**: there is no separate fine queue job: fines are applied when `expireOverdueDutyTask` runs on an eligible task. After the row is `expired`, later cron passes skip it, so the fine path does not re-run for the same task. Retrying before the status flip (or duplicate maintenance + cron in the same window) can still double-apply unless ledger deduplication is added later.
+- **Task metadata**: `is_fine` may exist on assignment types / Appwrite schema, but the current expiry + fine path does **not** read or write it; the ledger row is the record of the debit (`amount` positive with `is_debit: true` per `PointsService`).
+- **Idempotency**: once a task is `expired`, later `expireDutiesJob` scans (open/pending overdue only) do not revisit it, so the fine is not retried on subsequent hourly runs. If `awardPoints` fails, the task stays `expired` without a compensating retry job. Concurrent expiry of the **same** task before the status update (e.g. overlapping maintenance and cron) could still double-apply until a ledger-level dedup strategy exists.
 
 ## 3.2 One-Off Duty Flow
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@
 - **Server env schema**: Extended `serverEnvSchema` with `DISCORD_ROLE_ID_*` keys so the same validation used by the diagnose script matches the Discord role checks it runs.
 - **Docs**: Clarified in `docs/architecture.md` that duty expiry is pipeline-driven, not bus-driven; expanded `docs/behavior.md` with pipeline order, fine/ledger behavior, and idempotency notes.
 
+## 2026-03-23: Docs — housing pipeline vs code (reconciliation)
+
+- **Behavior reference**: Updated `docs/behavior.md` so the documented hourly sequence matches `HousingTimeDrivenPipeline` (six steps, no separate fine-retry job) and fine/idempotency wording matches `expireOverdueDutyTask` + `PointsService` (no `pendingFinesJob`, `[task:…]` markers, or `fineTaskId` in the current codebase).
+
 ## 2026-03-22: Housing time-driven pipeline unification
 
 - **Appwrite note**: `scripts/add-expired-admin-notification-enum.ts` documents how to add `expired_admin` when `notification_level` is an enum; staging uses a **string** attribute so no enum migration was required there.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type of change

- [x] Chore (`chore`) — documentation only

## Summary

Reconciled `docs/behavior.md` (and a short `docs/changelog.md` entry) with the housing code on latest `staging`.

**Verified on commit `8b5a5b72798e77568af0a7fa456826fa6a757555`:** `pendingFinesJob`, `hasPersistedMissedDutyFine`, `fineTaskId`, `[task:` in fine reasons, and `is_fine` handling in the expiry path are **absent** from the repository. The docs no longer imply a separate hourly fine-retry job or ledger-marker idempotency for missed-duty fines.

## Technical breakdown

- **docs/behavior.md**: Documented the six-step `HousingTimeDrivenPipeline` order (unlock → recurring notify → urgent → expire duties → notify expired → ensure future), clarified that there is no additional fine-retry step after `expireDutiesJob`, and aligned fine wording with `expireOverdueDutyTask` + `PointsService` (`Missed Duty: <title>` only; no task-id suffix).
- **docs/changelog.md**: Added a reconciliation note for traceability.

## Server env (`readServerEnv` / `serverEnvSchema`)

Call sites are `lib/infrastructure/config/env.ts` (production path validates full `serverEnvSchema`, including `DISCORD_ROLE_ID_*`) and `scripts/diagnose-staging.ts` (uses `serverEnvSchema.safeParse(readServerEnv())` before Discord checks). No other legitimate path loads validated server env without those role IDs; with `SKIP_ENV_VALIDATION=true`, `env` falls back to a cast of raw `process.env` (documented in AGENTS.md).

## Verification

- [x] Updated `docs/changelog.md`
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit`
- [x] `npm run test -- --run`
- [x] `SKIP_ENV_VALIDATION=true npm run build`
- [ ] UI N/A (docs only)

## Risk

None (documentation only).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33af3143-5869-45f8-a272-d52d28143a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33af3143-5869-45f8-a272-d52d28143a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated system behavior documentation to accurately reflect current implementation details regarding overdue duty handling, fine application, and the hourly execution pipeline.
  * Added changelog entry documenting documentation reconciliation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->