### PR TITLE
refactor(housing): HOUSING_BATCH cron naming and daily semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ _Problem: Fairness and manual overhead in chore assignment._
 
 The Housing module uses a weighted Round-Robin algorithm to assign duties.
 
-- **Cron Architecture**: The `/api/cron` route (Vercel Cron, see `vercel.json`) runs the housing time-driven pipeline (unlock, notify, expire, etc.).
+- **Cron Architecture**: The `/api/cron` route (Vercel Cron, see `vercel.json`) invokes `job=HOUSING_BATCH` on the production deployment to run the full housing time-driven pipeline (unlock, notify, expire, etc.) on a **daily** schedule on Hobby.
 - **State Machine**: Tasks move through a strict lifecycle: `Scheduled -> Open -> Pending Review -> Approved/Rejected`.
 - **Optimistic UI**: Client components utilize `router.refresh()` for mutations, providing near-instant feedback while preserving server state consistency.
 

--- a/app/api/cron/route.test.ts
+++ b/app/api/cron/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 type CronServiceMock = {
-  runHourly: ReturnType<typeof vi.fn>;
+  runHousingScheduledBatch: ReturnType<typeof vi.fn>;
   expireDuties: ReturnType<typeof vi.fn>;
   ensureFutureTasks: ReturnType<typeof vi.fn>;
 };
@@ -12,14 +12,16 @@ type ContainerMock = {
 
 type RouteFixtureOptions = {
   cronSecret?: string;
-  runHourly?: () => Promise<unknown>;
+  runHousingScheduledBatch?: () => Promise<unknown>;
   expireDuties?: () => Promise<unknown>;
   ensureFutureTasks?: () => Promise<unknown>;
 };
 
 async function loadRouteFixture(options: RouteFixtureOptions = {}) {
   const cronServiceMock: CronServiceMock = {
-    runHourly: vi.fn(options.runHourly ?? (async () => ({ ok: true }))),
+    runHousingScheduledBatch: vi.fn(
+      options.runHousingScheduledBatch ?? (async () => ({ ok: true })),
+    ),
     expireDuties: vi.fn(options.expireDuties ?? (async () => ({ ok: true }))),
     ensureFutureTasks: vi.fn(
       options.ensureFutureTasks ?? (async () => ({ ok: true })),
@@ -61,7 +63,7 @@ describe("GET /api/cron", () => {
   it("returns 401 when bearer token is missing", async () => {
     const { GET } = await loadRouteFixture();
 
-    const response = await GET(createRequest("HOURLY"));
+    const response = await GET(createRequest("HOUSING_BATCH"));
     const payload = await response.json();
 
     expect(response.status).toBe(401);
@@ -80,7 +82,7 @@ describe("GET /api/cron", () => {
   it("returns 401 when bearer token is invalid", async () => {
     const { GET } = await loadRouteFixture();
 
-    const response = await GET(createRequest("HOURLY", "invalid"));
+    const response = await GET(createRequest("HOUSING_BATCH", "invalid"));
     const payload = await response.json();
 
     expect(response.status).toBe(401);
@@ -99,7 +101,7 @@ describe("GET /api/cron", () => {
   it("returns 401 when Authorization is not exactly Bearer <CRON_SECRET> (Vercel cron contract)", async () => {
     const { GET } = await loadRouteFixture();
 
-    const url = "https://example.com/api/cron?job=HOURLY";
+    const url = "https://example.com/api/cron?job=HOUSING_BATCH";
     const headers = new Headers();
     headers.set("Authorization", "Bearer  test-secret");
 
@@ -157,7 +159,7 @@ describe("GET /api/cron", () => {
   it("returns 500 when CRON_SECRET is not configured", async () => {
     const { GET } = await loadRouteFixture({ cronSecret: "" });
 
-    const response = await GET(createRequest("HOURLY", "test-secret"));
+    const response = await GET(createRequest("HOUSING_BATCH", "test-secret"));
     const payload = await response.json();
 
     expect(response.status).toBe(500);
@@ -173,31 +175,31 @@ describe("GET /api/cron", () => {
     });
   }, 15000);
 
-  it("returns 200 and dispatches HOURLY job", async () => {
-    const hourlyResult = { processed: 7, errors: [] };
+  it("returns 200 and dispatches HOUSING_BATCH job", async () => {
+    const batchResult = { processed: 7, errors: [] };
     const { GET, cronServiceMock } = await loadRouteFixture({
-      runHourly: async () => hourlyResult,
+      runHousingScheduledBatch: async () => batchResult,
     });
 
-    const response = await GET(createRequest("HOURLY", "test-secret"));
+    const response = await GET(createRequest("HOUSING_BATCH", "test-secret"));
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(cronServiceMock.runHourly).toHaveBeenCalledTimes(1);
+    expect(cronServiceMock.runHousingScheduledBatch).toHaveBeenCalledTimes(1);
     expect(payload).toEqual({
       success: true,
-      result: hourlyResult,
+      result: batchResult,
     });
   }, 15000);
 
   it("returns 500 when job execution throws", async () => {
     const { GET } = await loadRouteFixture({
-      runHourly: async () => {
+      runHousingScheduledBatch: async () => {
         throw new Error("explode");
       },
     });
 
-    const response = await GET(createRequest("HOURLY", "test-secret"));
+    const response = await GET(createRequest("HOUSING_BATCH", "test-secret"));
     const payload = await response.json();
 
     expect(response.status).toBe(500);

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -13,7 +13,7 @@ const ERROR_CODES = {
 } as const;
 
 const CRON_JOBS = {
-  HOURLY: "HOURLY",
+  HOUSING_BATCH: "HOUSING_BATCH",
   EXPIRE_DUTIES: "EXPIRE_DUTIES",
   ENSURE_FUTURE_TASKS: "ENSURE_FUTURE_TASKS",
 } as const;
@@ -95,8 +95,8 @@ export async function GET(req: Request) {
     const { cronService } = getContainer();
 
     switch (job) {
-      case CRON_JOBS.HOURLY:
-        result = await cronService.runHourly();
+      case CRON_JOBS.HOUSING_BATCH:
+        result = await cronService.runHousingScheduledBatch();
         break;
       case CRON_JOBS.EXPIRE_DUTIES:
         result = await cronService.expireDuties();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ The heart of the software. Has **no imports from infrastructure, application, or
 Orchestrates business logic and use cases.
 
 - **Services**: `DutyService`, `LedgerService`, `LibraryService`, `ScheduleService`, `AdminService`.
-- **Event Handlers**: Asynchronous listeners for domain events published via `DomainEventBus` (task lifecycle notifications, points on approve/reject). Overdue duty expiry and next-instance generation run in the hourly housing pipeline (`expireOverdueDutyTask`), not via a domain event.
+- **Event Handlers**: Asynchronous listeners for domain events published via `DomainEventBus` (task lifecycle notifications, points on approve/reject). Overdue duty expiry and next-instance generation run in the scheduled housing batch pipeline (`expireOverdueDutyTask`), not via a domain event.
 - **Scheduling**: Cron handlers (`lib/application/services/jobs`) for recurring logic — `UnlockTasksJob`, `NotifyRecurringJob`, `NotifyUrgentJob`, `ExpireDutiesJob`, `NotifyExpiredJob`, `EnsureFutureTasksJob`.
 
 ### 3. Infrastructure Layer (`lib/infrastructure`)
@@ -66,4 +66,4 @@ Concrete implementations of domain ports.
 - **Hosting**: **Vercel** builds and serves the Next.js app from the GitHub repo (**Preview** from **`main`** and other branches as configured; **Production** from **`production`** when set as the production branch).
 - **Backend**: **Appwrite** (Auth, Databases) is configured via env vars injected at deploy time; it does not host the web app.
 - **CI**: GitHub Actions runs quality gates (lint, type check, test, build) on pushes and PRs.
-- **Cron**: Vercel Cron triggers `/api/cron?job=HOURLY` on the **production** deployment per `vercel.json`; Vercel sends `Authorization: Bearer <CRON_SECRET>` when that env var is set on the project
+- **Cron**: Vercel Cron triggers `/api/cron?job=HOUSING_BATCH` on the **production** deployment per `vercel.json` (once daily on the current schedule); Vercel sends `Authorization: Bearer <CRON_SECRET>` when that env var is set on the project

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -62,15 +62,15 @@ This document is the durable behavioral reference for the Housing module.
 5. Admin approves -> `approved`.
 6. Next recurring instance is generated.
 7. If missed deadline, task transitions to `expired` and fine behavior is triggered.
-   - Assignments use `is_fine`: set `false` when the row is expired with a pending ledger fine; set `true` only after `awardPoints` succeeds. Hourly cron runs `pendingFinesJob` to retry fines when the ledger call failed after expiry.
+   - Assignments use `is_fine`: set `false` when the row is expired with a pending ledger fine; set `true` only after `awardPoints` succeeds. Each housing scheduled batch run executes `pendingFinesJob` to retry fines when the ledger call failed after expiry.
    - Missed-duty fine ledger rows embed the task id in `reason` (`[task:<id>]`) so `expireOverdueDutyTask` and `pendingFinesJob` can skip `awardPoints` when a matching fine already exists (avoids double charges if `is_fine` was not persisted).
 8. Overdue transition is canonicalized through shared expiry logic and may run from:
    - cron (`expireDutiesJob`) as the primary scheduled path, and
    - dashboard maintenance as a fallback path for assigned-user views.
 
-### Hourly pipeline: overdue duties, fines, and ledger
+### Scheduled housing batch: overdue duties, fines, and ledger
 
-The ordered hourly sequence is implemented in `HousingTimeDrivenPipeline.runFullHourlyCycle` (`lib/application/services/jobs/housing-time-driven.pipeline.ts`):
+The full ordered sequence runs on the platform-scheduled batch (daily on current Vercel Hobby config), implemented in `HousingTimeDrivenPipeline.runFullHousingScheduledCycle` (`lib/application/services/jobs/housing-time-driven.pipeline.ts`):
 
 1. **Unlock** (`UnlockTasksJob`)
 2. **Recurring notify** (`NotifyRecurringJob`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Project Log
 
+## 2026-03-23: Cron — rename housing job to `HOUSING_BATCH` (scheduled batch semantics)
+
+- **API / config**: `job=HOUSING_BATCH` replaces `HOURLY` for the platform-scheduled housing pipeline; `vercel.json` cron path updated accordingly.
+- **Code**: `CronService.runHousingScheduledBatch`, `HousingTimeDrivenPipeline.runFullHousingScheduledCycle`; logs use `job: "HOUSING_BATCH"`.
+- **Docs**: `docs/deployment.md`, `docs/architecture.md`, `docs/behavior.md`, `docs/platform-map.md`, `docs/tech-stack.md`, `README.md` — wording aligned with **once-per-day** Vercel Hobby scheduling (no “hourly platform trigger” implication).
+
 ## 2026-03-23: Cron — Hobby plan daily schedule (1 AM Eastern intent)
 
 - **`vercel.json`**: Replaced `*/15 * * * *` with **`0 6 * * *`** (once per day, UTC) to satisfy Vercel Hobby’s maximum frequency and avoid deploy failures.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -230,30 +230,30 @@ This is often **cold start** or heavy SSR on the first hit after idle.
      "${BASE_URL%/}/api/cron"
    ```
 
-2. Interpret preflight status before running `job=HOURLY`:
-   - When the server returns `400` with `INVALID_JOB`, auth and runtime cron config are aligned (safe to run HOURLY).
+2. Interpret preflight status before running `job=HOUSING_BATCH`:
+   - When the server returns `400` with `INVALID_JOB`, auth and runtime cron config are aligned (safe to run the housing batch).
    - If you receive `401` with `UNAUTHORIZED`, the bearer value does not match deployed runtime `CRON_SECRET` (header must be exactly `Authorization: Bearer <CRON_SECRET>` per [Vercel cron docs](https://vercel.com/docs/cron-jobs/manage-cron-jobs)).
    - When `500` shows `CRON_SECRET_MISSING` in `error.details.reason` (response `error.code` is `SERVER_CONFIG_ERROR`), the deployed runtime is missing `CRON_SECRET` in the hosting environment.
    - When `500` indicates `JOB_EXECUTION_FAILED`, runtime dependencies failed during execution; inspect app logs.
 3. In **Vercel** for the target deployment environment (Preview/staging or Production), verify `CRON_SECRET` is present and non-empty and `NEXT_PUBLIC_APP_URL` matches the deployed site URL for that environment.
 4. **Redeploy** after changing environment variables if the platform does not hot-reload them for existing deployments (Vercel typically requires a new deployment for env changes to take effect).
-5. To run the HOURLY job manually against a URL you control:
+5. To run the housing scheduled batch manually against a URL you control:
 
    ```bash
    curl --silent --show-error -X GET \
      -H "Authorization: Bearer ${CRON_SECRET}" \
-     "${BASE_URL%/}/api/cron?job=HOURLY"
+     "${BASE_URL%/}/api/cron?job=HOUSING_BATCH"
    ```
 
 6. Confirm endpoint auth contract is Bearer header (`Authorization: Bearer <CRON_SECRET>`), not query-string `key`.
 
 ## Cron Jobs
 
-- **Scheduler**: [Vercel Cron](https://vercel.com/docs/cron-jobs) via root `vercel.json`: GET `/api/cron?job=HOURLY` **once per day** at **`0 6 * * *`** (minute `0` of hour `6`, every day, **UTC**).
+- **Scheduler**: [Vercel Cron](https://vercel.com/docs/cron-jobs) via root `vercel.json`: GET `/api/cron?job=HOUSING_BATCH` **once per day** at **`0 6 * * *`** (minute `0` of hour `6`, every day, **UTC**).
   - **Hobby plan**: Vercel allows at most one invocation per day for cron; the expression must not run more frequently than daily.
   - **Hobby timing**: Invocations are distributed within the scheduled **hour** (roughly any time from `06:00:00` through `06:59:59` UTC), not necessarily on the minute — see [Cron jobs accuracy](https://vercel.com/docs/cron-jobs/manage-cron-jobs#cron-jobs-accuracy).
   - **Why 06:00 UTC**: Duties go overdue at **midnight Eastern**. We target **~1:00 AM Eastern** so a run that lands early in the allowed window still falls **after** midnight. **Note:** cron expressions are **UTC-only**. `06:00` UTC is **1:00 AM Eastern Standard Time** and **2:00 AM Eastern Daylight Time**; during EDT the same UTC hour corresponds to **2:00–2:59 AM** local on the **same** Eastern calendar day (still after local midnight that day).
 - **Which deployment**: Per Vercel’s documentation, cron invokes the project’s **production deployment URL** only — preview deployments are not targeted by scheduled cron.
-- **`job=HOURLY`**: Logical batch name for hourly-cadence work (unlock, notify, expire) that remains safe to run more often than once per hour.
+- **`job=HOUSING_BATCH`**: Full housing time-driven pipeline (unlock, notify, urgent window, expire, fine retries, expired notify, ensure future). On Hobby this is invoked **once per day** by Vercel; the handler is idempotent enough for occasional manual re-runs if needed.
 - **Auth**: Set `CRON_SECRET` on the Vercel project; Vercel sends it as `Authorization: Bearer <CRON_SECRET>` when invoking the route. The handler compares the header to `Bearer ${CRON_SECRET}` as in Vercel’s recommended pattern. Do not pass the secret as a query parameter.
 - **Manual / local testing**: Hit the route with curl (or the deployment URL in a browser will not send the secret — use curl). Vercel attaches `vercel-cron/1.0` as the user agent for platform-triggered runs.

--- a/docs/platform-map.md
+++ b/docs/platform-map.md
@@ -9,7 +9,7 @@ This page exists so nobody confuses **where the app runs** with **where data and
 | **File storage (library uploads)** | **AWS S3** | Credentials in **Vercel** env. |
 | **Discord (roles, DMs, slash commands)** | **Discord API** | Bot token and role IDs in **Vercel** env. Command registration: `npm run discord:register` (manual). |
 | **CI (lint, test, build)** | **GitHub Actions** | `ci.yml` — quality gates only; it does **not** deploy the Next.js app. |
-| **Scheduled jobs hitting `/api/cron`** | **Vercel Cron** | `vercel.json` — GET to **production** deployment; Vercel sends `Authorization: Bearer` using project `CRON_SECRET`. |
+| **Scheduled jobs hitting `/api/cron`** | **Vercel Cron** | `vercel.json` — GET `/api/cron?job=HOUSING_BATCH` to **production** deployment (once daily on current config); Vercel sends `Authorization: Bearer` using project `CRON_SECRET`. |
 
 ## Git branches (do not mix with “staging” the environment)
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -17,7 +17,7 @@
 ## Integrations
 
 - **Messaging/Identity**: Discord API (for role verification and notifications)
-- **Scheduling**: Next.js route handlers (`/api/cron`) triggered by [Vercel Cron](https://vercel.com/docs/cron-jobs) (`vercel.json`)
+- **Scheduling**: Next.js route handlers (`/api/cron?job=…`) triggered by [Vercel Cron](https://vercel.com/docs/cron-jobs) (`vercel.json`); production schedule uses `job=HOUSING_BATCH` once per day (see `docs/deployment.md`).
 
 ## Architecture & Patterns
 

--- a/lib/application/services/housing/maintenance.service.ts
+++ b/lib/application/services/housing/maintenance.service.ts
@@ -3,7 +3,8 @@
  *
  * Per-user fallback when cron has not run yet: unlock eligible tasks, expire overdue duties (same path as
  * `expireOverdueDutyTask` / cron), and unclaim expired bounties. Does **not** duplicate recurring/urgent/expired
- * Discord notifications or `ensureFutureTasksJob` — those stay in the hourly cron pipeline (`housing-time-driven.pipeline.ts`).
+ * Discord notifications or `ensureFutureTasksJob` — those stay in the platform-scheduled housing batch
+ * (`housing-time-driven.pipeline.ts`).
  */
 
 import { ITaskRepository } from "@/lib/domain/ports/task.repository";

--- a/lib/application/services/housing/schedule.service.ts
+++ b/lib/application/services/housing/schedule.service.ts
@@ -771,7 +771,7 @@ export class ScheduleService implements IScheduleService {
   }
 
   /**
-   * Soft-deactivates the schedule before deleting future rows so hourly `ensureFutureTasksJob`
+   * Soft-deactivates the schedule before deleting future rows so the scheduled `ensureFutureTasksJob` pass
    * cannot recreate instances while cleanup runs (see `docs/behavior.md` delete rules).
    */
   async deleteTaskThisAndFuture(task: HousingTask, effectiveFromDueAt: string) {

--- a/lib/application/services/jobs/cron.service.test.ts
+++ b/lib/application/services/jobs/cron.service.test.ts
@@ -5,7 +5,7 @@ import { MockFactory } from "@/lib/test/mock-factory";
 import type { IPointsService } from "@/lib/domain/ports/services/points.service.port";
 import type { IScheduleService } from "@/lib/domain/ports/services/schedule.service.port";
 
-describe("CronService.runHourly", () => {
+describe("CronService.runHousingScheduledBatch", () => {
   const taskRepository = MockFactory.createTaskRepository();
   const ledgerRepository = MockFactory.createLedgerRepository();
   const pointsService = {
@@ -17,7 +17,10 @@ describe("CronService.runHourly", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(HousingTimeDrivenPipeline, "runFullHourlyCycle").mockResolvedValue({
+    vi.spyOn(
+      HousingTimeDrivenPipeline,
+      "runFullHousingScheduledCycle",
+    ).mockResolvedValue({
       unlocked: 1,
       recurring_notified: 1,
       urgent: 1,
@@ -27,7 +30,7 @@ describe("CronService.runHourly", () => {
     });
   });
 
-  it("delegates to HousingTimeDrivenPipeline.runFullHourlyCycle and returns its stats", async () => {
+  it("delegates to HousingTimeDrivenPipeline.runFullHousingScheduledCycle and returns its stats", async () => {
     const cronService = new CronService(
       HousingTimeDrivenPipeline,
       taskRepository,
@@ -36,7 +39,7 @@ describe("CronService.runHourly", () => {
       ledgerRepository,
     );
 
-    const result = await cronService.runHourly();
+    const result = await cronService.runHousingScheduledBatch();
 
     expect(result).toEqual({
       unlocked: 1,
@@ -46,7 +49,9 @@ describe("CronService.runHourly", () => {
       skipped_unassigned: 0,
       errors: [],
     });
-    expect(HousingTimeDrivenPipeline.runFullHourlyCycle).toHaveBeenCalledWith(
+    expect(
+      HousingTimeDrivenPipeline.runFullHousingScheduledCycle,
+    ).toHaveBeenCalledWith(
       taskRepository,
       pointsService,
       scheduleService,

--- a/lib/application/services/jobs/cron.service.ts
+++ b/lib/application/services/jobs/cron.service.ts
@@ -1,8 +1,8 @@
 /**
  * Cron Service
  *
- * Delegates hourly housing work to {@link HousingTimeDrivenPipeline} so cron and dashboard maintenance
- * cannot drift on ordering or shared rules.
+ * Delegates the scheduled housing batch to {@link HousingTimeDrivenPipeline} so platform cron and
+ * dashboard maintenance cannot drift on ordering or shared rules.
  */
 
 import { HousingTimeDrivenPipeline } from "./housing-time-driven.pipeline";
@@ -33,16 +33,16 @@ export class CronService {
   ) {}
 
   /**
-   * Hourly Cron Job — full time-driven housing pipeline (see `housing-time-driven.pipeline.ts`).
+   * Vercel-scheduled housing batch — full time-driven pipeline (see `housing-time-driven.pipeline.ts`).
    */
-  async runHourly(): Promise<CronResult> {
+  async runHousingScheduledBatch(): Promise<CronResult> {
     console.log("[CronService]", {
-      job: "HOURLY",
+      job: "HOUSING_BATCH",
       phase: "start",
       startedAt: new Date().toISOString(),
     });
 
-    const stats = await this.housingTimeDrivenPipeline.runFullHourlyCycle(
+    const stats = await this.housingTimeDrivenPipeline.runFullHousingScheduledCycle(
       this.taskRepository,
       this.pointsService,
       this.scheduleService,
@@ -50,7 +50,7 @@ export class CronService {
     );
 
     console.log("[CronService]", {
-      job: "HOURLY",
+      job: "HOUSING_BATCH",
       phase: "completed",
       ...stats,
     });

--- a/lib/application/services/jobs/handlers/ensure-future-tasks.job.ts
+++ b/lib/application/services/jobs/handlers/ensure-future-tasks.job.ts
@@ -8,7 +8,7 @@ import { calculateNextInstance } from "@/lib/utils/scheduler";
  *   schedule, `create` duty rows, `updateSchedule` for `last_generated_at`). Callers must not pass a repository
  *   that swallows errors silently.
  * @returns Resolves to `void`. On unexpected repository failures, logs `🔥 EnsureFutureTasksJob Failed` and
- *   does not rethrow (hourly cron continues). Per-schedule failures (e.g. cannot compute next instance) log and
+ *   does not rethrow (scheduled housing batch continues). Per-schedule failures (e.g. cannot compute next instance) log and
  *   `continue` to the next schedule.
  */
 export const ensureFutureTasksJob = async (

--- a/lib/application/services/jobs/housing-time-driven.pipeline.test.ts
+++ b/lib/application/services/jobs/housing-time-driven.pipeline.test.ts
@@ -51,7 +51,7 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-describe("HousingTimeDrivenPipeline.runFullHourlyCycle", () => {
+describe("HousingTimeDrivenPipeline.runFullHousingScheduledCycle", () => {
   const taskRepository = MockFactory.createTaskRepository();
   const ledgerRepository = MockFactory.createLedgerRepository();
   const pointsService = {
@@ -109,7 +109,7 @@ describe("HousingTimeDrivenPipeline.runFullHourlyCycle", () => {
     );
     hoisted.ensureFutureRun.mockReturnValue(d7.promise.then(() => undefined));
 
-    const pipelinePromise = HousingTimeDrivenPipeline.runFullHourlyCycle(
+    const pipelinePromise = HousingTimeDrivenPipeline.runFullHousingScheduledCycle(
       taskRepository,
       pointsService,
       scheduleService,

--- a/lib/application/services/jobs/housing-time-driven.pipeline.ts
+++ b/lib/application/services/jobs/housing-time-driven.pipeline.ts
@@ -11,8 +11,9 @@
  * 6. **Ensure future tasks** — Self-heal missing future instances for active schedules last so new rows reflect
  *    current schedule state and do not race earlier expiry/generation steps.
  *
- * Cron runs the full sequence. Per-user maintenance reuses steps 1, 4 (subset), and bounty unclaim only —
- * notifications and global ensure-future stay on cron to avoid duplicate Discord noise and duplicate healing.
+ * The platform-scheduled batch (daily on current Vercel Hobby config) runs the full sequence. Per-user
+ * maintenance reuses steps 1, 4 (subset), and bounty unclaim only — notifications and global ensure-future
+ * stay on the scheduled batch to avoid duplicate Discord noise and duplicate healing.
  */
 
 import { getContainer } from "@/lib/infrastructure/container";
@@ -40,7 +41,7 @@ export interface HousingTimeDrivenPipelineResult {
 }
 
 export const HousingTimeDrivenPipeline = {
-  async runFullHourlyCycle(
+  async runFullHousingScheduledCycle(
     taskRepository: ITaskRepository,
     pointsService: IPointsService,
     scheduleService: IScheduleService,
@@ -100,7 +101,7 @@ export const HousingTimeDrivenPipeline = {
   async runFromContainer(): Promise<HousingTimeDrivenPipelineResult> {
     const { taskRepository, pointsService, scheduleService, ledgerRepository } =
       getContainer();
-    return this.runFullHourlyCycle(
+    return this.runFullHousingScheduledCycle(
       taskRepository,
       pointsService,
       scheduleService,

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
-      "path": "/api/cron?job=HOURLY",
+      "path": "/api/cron?job=HOUSING_BATCH",
       "schedule": "0 6 * * *"
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type of Change

- [x] Refactor (`refactor`)

## Summary

Renames the platform-scheduled housing cron job from `HOURLY` to `HOUSING_BATCH`, aligns `CronService` and `HousingTimeDrivenPipeline` method names, updates `vercel.json`, and refreshes operational docs so readers do not infer hourly or 12-minute platform triggers. Vercel Hobby remains **once per day** at `0 6 * * *` UTC per `vercel.json`.

## Technical Breakdown

- **`/api/cron`**: `CRON_JOBS.HOUSING_BATCH`, dispatches `cronService.runHousingScheduledBatch()`.
- **`CronService`**: `runHousingScheduledBatch`; structured logs use `job: "HOUSING_BATCH"`.
- **`HousingTimeDrivenPipeline`**: `runFullHousingScheduledCycle`; `runFromContainer` calls the renamed method.
- **`vercel.json`**: cron path `/api/cron?job=HOUSING_BATCH`.
- **Docs**: `docs/deployment.md`, `docs/architecture.md`, `docs/behavior.md`, `docs/platform-map.md`, `docs/tech-stack.md`, `README.md`; changelog entry dated 2026-03-23.
- **Comments**: `maintenance.service.ts`, `schedule.service.ts`, `ensure-future-tasks.job.ts` distinguish scheduled batch vs per-user maintenance.

## Risk Assessment

- **Migrations:** None.
- **Security:** Unchanged Bearer / `CRON_SECRET` validation.
- **Impact:** Any external automation still calling `job=HOURLY` must switch to `job=HOUSING_BATCH` (Vercel project cron path updated in-repo).

## Verification

- [x] Updated `docs/changelog.md`.
- [x] Ran `npm run lint`, `npx tsc --noEmit`, `npm run test -- --run`, `SKIP_ENV_VALIDATION=true npm run build`.
- [ ] UI N/A (cron/docs only).

---

### Self-audit

1. **Grep (post-change)**  
   - `HOURLY` / `runHourly` / `runFullHourlyCycle`: **0 matches** in source/config; **only** in `docs/changelog.md` (new entry explaining the rename + historical rows left intact).  
   - `hourly` in **current** docs (excluding changelog history): **0 matches** in `docs/*.md` except `docs/changelog.md`.

2. **`vercel.json` cron path:** `/api/cron?job=HOUSING_BATCH` (schedule unchanged: `0 6 * * *`).

3. **Primary scheduled job:** Docs describe **`job=HOUSING_BATCH`** as the Vercel-scheduled housing batch; `EXPIRE_DUTIES` and `ENSURE_FUTURE_TASKS` remain documented as optional/manual job ids where applicable.

4. **Files touched:** `vercel.json`, `app/api/cron/route.ts`, `app/api/cron/route.test.ts`, `lib/application/services/jobs/cron.service.ts`, `lib/application/services/jobs/cron.service.test.ts`, `lib/application/services/jobs/housing-time-driven.pipeline.ts`, `lib/application/services/jobs/housing-time-driven.pipeline.test.ts`, `lib/application/services/housing/maintenance.service.ts`, `lib/application/services/housing/schedule.service.ts`, `lib/application/services/jobs/handlers/ensure-future-tasks.job.ts`, `docs/deployment.md`, `docs/architecture.md`, `docs/behavior.md`, `docs/platform-map.md`, `docs/tech-stack.md`, `docs/changelog.md`, `README.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af79dcf-eb77-45af-b00f-98ec49096bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af79dcf-eb77-45af-b00f-98ec49096bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal cron job naming and scheduling infrastructure for clarity and consistency.

* **Documentation**
  * Updated architecture, deployment, and technical documentation to reflect refined scheduling terminology and cron configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->