### PR TITLE
docs: alignment fixes on documentation-structure base

### DIFF
--- a/docs/deployment/ci.md
+++ b/docs/deployment/ci.md
@@ -17,7 +17,7 @@ Quality gates run via GitHub Actions (`.github/workflows/ci.yml`). This workflow
 | `test` | `npm run test -- --run` | Vitest — all tests must pass |
 | `coverage-critical` | `npm run test:coverage:critical` | Coverage thresholds on critical modules |
 | `e2e-smoke` | `npm run test:e2e` | Playwright smoke tests for deployment-critical routes |
-| `build` | `npm run build` | Next.js build with CI placeholder env vars |
+| `build` | `SKIP_ENV_VALIDATION=true npm run build` | Next.js build with CI placeholder env vars |
 | `quality-gate` | Aggregate check | Fails if any required job above is not `success` |
 
 All jobs run `npm ci` with `actions/setup-node` npm cache independently (no shared `node_modules` artifact — zip round-trip breaks `.bin` symlinks).

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -36,7 +36,9 @@
 | Discord Core  | `DISCORD_APP_ID`, `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_HOUSING_CHANNEL_ID` |
 | Discord Roles | `DISCORD_ROLE_ID_BROTHER`, `DISCORD_ROLE_ID_CABINET`, `DISCORD_ROLE_ID_HOUSING_CHAIR`  |
 | AWS/S3        | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME`          |
-| Cron          | `CRON_SECRET`                                                                          |
+| Cron (optional) | `CRON_SECRET` — set when Vercel cron or authenticated `/api/cron` use is enabled |
+
+In `serverEnvSchema` (`lib/infrastructure/config/server-env-schema.ts`), **`CRON_SECRET` is optional** (Zod `.optional()`). Omit it only when cron is disabled and nothing calls `/api/cron`; otherwise configure a non-empty secret in Vercel (and locally) so the endpoint can authorize requests.
 
 `SKIP_ENV_VALIDATION=true` is intended for local fallback scenarios only when intentionally bypassing strict checks. CI should validate against a complete placeholder matrix, and runtime staging/production should validate with real environment values.
 
@@ -60,7 +62,7 @@ Before promoting a merge to **`production`**, verify the **Vercel Production** e
 - `DISCORD_ROLE_ID_BROTHER`
 - `DISCORD_ROLE_ID_CABINET`
 - `DISCORD_ROLE_ID_HOUSING_CHAIR`
-- `CRON_SECRET`
+- `CRON_SECRET` (when using Vercel cron or manual `/api/cron` invocations; optional in schema otherwise)
 
 For production specifically, the three `DISCORD_ROLE_ID_*` keys must be present before deployment. Missing role IDs can break role-gated runtime flows even when unrelated routes (such as image proxying) build successfully.
 

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -58,9 +58,12 @@ This is often **cold start** or heavy SSR on the first hit after idle.
    BASE_URL="<app-url>"
    CRON_SECRET="<cron-secret-for-that-deployment>"
    curl --silent --show-error \
+     -w '\n%{http_code}\n' \
      -H "Authorization: Bearer ${CRON_SECRET}" \
      "${BASE_URL%/}/api/cron"
    ```
+
+   The response body is printed first; the **last line** is the numeric HTTP status (for example `400`, `401`, or `500`).
 
 2. Interpret preflight status before running `job=HOUSING_BATCH`:
    - When the server returns `400` and the body has `error.code` **`INVALID_JOB`** with `error.details.reason` **`INVALID_JOB_PARAMETER`** (preflight with no `job` query param), auth and runtime cron config are aligned (safe to run the housing batch).


### PR DESCRIPTION
## Type of Change

- [x] Chore (`chore`)

## Summary

Documentation and link-alignment work stacked on **`c/repository-documentation-structure-95d8`**. Targets the **base feature branch**, not `main`.

## Contents (this branch vs base)

- CI docs: `build` job command matches `SKIP_ENV_VALIDATION=true npm run build`; build env narrative.
- Environments: Discord matrix + optional `CRON_SECRET` per `server-env-schema.ts`.
- Branch protection: separate POST (create) vs PUT (update) ruleset examples.
- Troubleshooting: cron `INVALID_JOB` / `INVALID_JOB_PARAMETER`; preflight `curl` with HTTP status via `-w`.
- Testing doc: critical coverage thresholds match `vitest.critical.config.ts`.
- Stale doc link fixes (as in branch history).

## Verification

- [x] `npm run lint`, `npx tsc --noEmit`, `npm run test -- --run`, `SKIP_ENV_VALIDATION=true npm run build`