### PR TITLE
fix(library): backwork uploads via presigned S3 (Vercel body limit)

### DIFF
--- a/app/dashboard/library/upload/page.tsx
+++ b/app/dashboard/library/upload/page.tsx
@@ -29,13 +29,16 @@ import {
   checkDuplicateResourceAction,
   getMetadataAction,
 } from "@/lib/presentation/actions/library/read.actions";
+import { validatedLibraryUploadContentType } from "@/lib/utils/library-upload-content-type";
 
 async function putWithRetry(
   url: string,
   file: File,
   maxRetries = 2,
 ): Promise<Response> {
-  const contentType = file.type || "application/pdf";
+  const contentType = validatedLibraryUploadContentType(
+    file.type || "application/pdf",
+  );
   let lastResponse: Response | null = null;
   let lastError: unknown;
 
@@ -259,16 +262,12 @@ export default function UnifiedUploadPage() {
         await presignLibraryUploadAction(
           {
             filename: stdName,
-            contentType: fileToUpload.type || "application/pdf",
+            contentType: validatedLibraryUploadContentType(
+              fileToUpload.type || "application/pdf",
+            ),
           },
           jwt,
         );
-
-      if (sanitizedFilename !== fileToUpload.name) {
-        fileToUpload = new File([fileToUpload], sanitizedFilename, {
-          type: fileToUpload.type || "application/pdf",
-        });
-      }
 
       const putResponse = await putWithRetry(uploadUrl, fileToUpload);
 

--- a/app/dashboard/library/upload/page.tsx
+++ b/app/dashboard/library/upload/page.tsx
@@ -36,9 +36,7 @@ async function putWithRetry(
   file: File,
   maxRetries = 2,
 ): Promise<Response> {
-  const contentType = validatedLibraryUploadContentType(
-    file.type || "application/pdf",
-  );
+  const contentType = validatedLibraryUploadContentType();
   let lastResponse: Response | null = null;
   let lastError: unknown;
 
@@ -262,9 +260,7 @@ export default function UnifiedUploadPage() {
         await presignLibraryUploadAction(
           {
             filename: stdName,
-            contentType: validatedLibraryUploadContentType(
-              fileToUpload.type || "application/pdf",
-            ),
+            contentType: validatedLibraryUploadContentType(),
           },
           jwt,
         );

--- a/app/dashboard/library/upload/page.tsx
+++ b/app/dashboard/library/upload/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "lucide-react";
 import toast from "react-hot-toast";
 import {
-  uploadFileAction,
+  presignLibraryUploadAction,
   createLibraryResourceAction,
 } from "@/lib/presentation/actions/library/manage.actions";
 import {
@@ -210,17 +210,30 @@ export default function UnifiedUploadPage() {
         });
       }
 
-      // 2. UPLOAD TO STORAGE
+      // 2. UPLOAD TO STORAGE (browser → S3 via presigned URL; avoids Vercel body limits)
       toast.loading("Uploading File...", { id: toastId });
 
-      // Use jwt generated earlier
-      const formData = new FormData();
-      formData.append("file", fileToUpload);
-      // formData.append("jwt", jwt); // Pass JWT
+      const { key: s3Key, uploadUrl } = await presignLibraryUploadAction(
+        {
+          filename: stdName,
+          contentType: fileToUpload.type || "application/pdf",
+        },
+        jwt,
+      );
 
-      // We need a server action that accepts FormData for upload
-      const uploadRes = await uploadFileAction(formData, jwt);
-      if (!uploadRes || !uploadRes.$id) throw new Error("Upload failed");
+      const putResponse = await fetch(uploadUrl, {
+        method: "PUT",
+        body: fileToUpload,
+        headers: {
+          "Content-Type": fileToUpload.type || "application/pdf",
+        },
+      });
+
+      if (!putResponse.ok) {
+        throw new Error(
+          `Storage upload failed (${putResponse.status}). If this persists, confirm the S3 bucket CORS allows PUT from your site origin.`,
+        );
+      }
 
       // 3. SUBMIT METADATA TO API
       toast.loading("Finalizing Record...", { id: toastId });
@@ -234,7 +247,7 @@ export default function UnifiedUploadPage() {
         : stickyMetadata.courseName || "";
 
       const resourceData = {
-        fileId: uploadRes.$id,
+        fileId: s3Key,
         metadata: {
           ...stickyMetadata,
           courseName,

--- a/app/dashboard/library/upload/page.tsx
+++ b/app/dashboard/library/upload/page.tsx
@@ -30,6 +30,48 @@ import {
   getMetadataAction,
 } from "@/lib/presentation/actions/library/read.actions";
 
+async function putWithRetry(
+  url: string,
+  file: File,
+  maxRetries = 2,
+): Promise<Response> {
+  const contentType = file.type || "application/pdf";
+  let lastResponse: Response | null = null;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": contentType },
+      });
+      if (response.ok) {
+        return response;
+      }
+      lastResponse = response;
+      const retryable = response.status >= 500 && response.status <= 599;
+      if (!retryable || attempt === maxRetries) {
+        return response;
+      }
+    } catch (e) {
+      lastError = e;
+      if (attempt === maxRetries) {
+        throw e;
+      }
+    }
+    const delayMs = 300 * 2 ** attempt;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  if (lastResponse) {
+    return lastResponse;
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Storage upload failed after retries");
+}
+
 // Dynamic import to prevent SSR evaluation of PDF library (uses DOMMatrix)
 const PdfRedactor = dynamic_(
   () => import("@/components/features/library/upload/PdfRedactor"),
@@ -213,21 +255,22 @@ export default function UnifiedUploadPage() {
       // 2. UPLOAD TO STORAGE (browser → S3 via presigned URL; avoids Vercel body limits)
       toast.loading("Uploading File...", { id: toastId });
 
-      const { key: s3Key, uploadUrl } = await presignLibraryUploadAction(
-        {
-          filename: stdName,
-          contentType: fileToUpload.type || "application/pdf",
-        },
-        jwt,
-      );
+      const { key: s3Key, uploadUrl, sanitizedFilename } =
+        await presignLibraryUploadAction(
+          {
+            filename: stdName,
+            contentType: fileToUpload.type || "application/pdf",
+          },
+          jwt,
+        );
 
-      const putResponse = await fetch(uploadUrl, {
-        method: "PUT",
-        body: fileToUpload,
-        headers: {
-          "Content-Type": fileToUpload.type || "application/pdf",
-        },
-      });
+      if (sanitizedFilename !== fileToUpload.name) {
+        fileToUpload = new File([fileToUpload], sanitizedFilename, {
+          type: fileToUpload.type || "application/pdf",
+        });
+      }
+
+      const putResponse = await putWithRetry(uploadUrl, fileToUpload);
 
       if (!putResponse.ok) {
         throw new Error(
@@ -252,7 +295,7 @@ export default function UnifiedUploadPage() {
           ...stickyMetadata,
           courseName,
           semester: stickyMetadata.semester,
-          standardizedFilename: stdName,
+          standardizedFilename: sanitizedFilename,
         },
       };
 

--- a/app/dashboard/library/upload/page.tsx
+++ b/app/dashboard/library/upload/page.tsx
@@ -257,13 +257,7 @@ export default function UnifiedUploadPage() {
       toast.loading("Uploading File...", { id: toastId });
 
       const { key: s3Key, uploadUrl, sanitizedFilename } =
-        await presignLibraryUploadAction(
-          {
-            filename: stdName,
-            contentType: validatedLibraryUploadContentType(),
-          },
-          jwt,
-        );
+        await presignLibraryUploadAction({ filename: stdName }, jwt);
 
       const putResponse = await putWithRetry(uploadUrl, fileToUpload);
 

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -35,8 +35,26 @@
 | Appwrite        | `NEXT_PUBLIC_APPWRITE_ENDPOINT`, `NEXT_PUBLIC_APPWRITE_PROJECT_ID`, `APPWRITE_API_KEY`                        |
 | Discord Core    | `DISCORD_APP_ID`, `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_HOUSING_CHANNEL_ID` |
 | Discord Roles   | `DISCORD_ROLE_ID_BROTHER`, `DISCORD_ROLE_ID_CABINET`, `DISCORD_ROLE_ID_HOUSING_CHAIR`                         |
-| AWS/S3          | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME` (bucket must allow browser `PUT` from your app origins via CORS for Library uploads) |
+| AWS/S3          | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME` (bucket must allow browser `PUT` from your app origins via CORS for Library uploads; see below) |
 | Cron (optional) | `CRON_SECRET` — set when Vercel cron or authenticated `/api/cron` use is enabled                              |
+
+**S3 CORS (Library browser uploads):** Presigned `PUT` requests originate from the browser. In the S3 bucket **Permissions → Cross-origin resource sharing (CORS)**, use rules that include your Vercel preview and production origins. Required elements for this app: **`AllowedMethods`** including `PUT`, **`AllowedHeaders`** including `Content-Type`, and **`ExposeHeaders`** including `ETag` (matches the signed request). Minimal example (replace origins with yours); full reference: [AWS S3 CORS configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html).
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://YOUR_VERCEL_PRODUCTION_HOSTNAME",
+      "https://YOUR_VERCEL_PREVIEW_HOSTNAME",
+      "http://127.0.0.1:REPLACE_WITH_DEV_PORT"
+    ],
+    "AllowedMethods": ["PUT"],
+    "AllowedHeaders": ["Content-Type"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3000
+  }
+]
+```
 
 In `serverEnvSchema` (`lib/infrastructure/config/server-env-schema.ts`), **`CRON_SECRET` is optional** (Zod `.optional()`). Omit it only when cron is disabled and nothing calls `/api/cron`; otherwise configure a non-empty secret in Vercel (and locally) so the endpoint can authorize requests.
 

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -40,6 +40,8 @@
 
 **S3 CORS (Library browser uploads):** Presigned `PUT` requests originate from the browser. In the S3 bucket **Permissions → Cross-origin resource sharing (CORS)**, use rules that include your Vercel preview and production origins. Required elements for this app: **`AllowedMethods`** including `PUT`, **`AllowedHeaders`** including `Content-Type`, and **`ExposeHeaders`** including `ETag` (matches the signed request). Minimal example (replace origins with yours); full reference: [AWS S3 CORS configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html).
 
+**Vercel previews:** Each preview deployment gets its own hostname, so you either list every preview URL you care about, or use a wildcard such as `https://*.vercel.app` (broader; use only if acceptable for your bucket). Replace `https://YOUR_VERCEL_PREVIEW_HOSTNAME` below with specific preview hostnames **or** that wildcard pattern.
+
 ```json
 [
   {

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -35,7 +35,7 @@
 | Appwrite        | `NEXT_PUBLIC_APPWRITE_ENDPOINT`, `NEXT_PUBLIC_APPWRITE_PROJECT_ID`, `APPWRITE_API_KEY`                        |
 | Discord Core    | `DISCORD_APP_ID`, `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_HOUSING_CHANNEL_ID` |
 | Discord Roles   | `DISCORD_ROLE_ID_BROTHER`, `DISCORD_ROLE_ID_CABINET`, `DISCORD_ROLE_ID_HOUSING_CHAIR`                         |
-| AWS/S3          | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME`                                 |
+| AWS/S3          | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME` (bucket must allow browser `PUT` from your app origins via CORS for Library uploads) |
 | Cron (optional) | `CRON_SECRET` — set when Vercel cron or authenticated `/api/cron` use is enabled                              |
 
 In `serverEnvSchema` (`lib/infrastructure/config/server-env-schema.ts`), **`CRON_SECRET` is optional** (Zod `.optional()`). Omit it only when cron is disabled and nothing calls `/api/cron`; otherwise configure a non-empty secret in Vercel (and locally) so the endpoint can authorize requests.

--- a/lib/application/services/library/library.service.test.ts
+++ b/lib/application/services/library/library.service.test.ts
@@ -14,13 +14,21 @@ describe("LibraryService", () => {
     getReadUrl: vi.fn().mockResolvedValue("https://S3-URL"),
     getUploadUrl: vi.fn().mockResolvedValue("https://S3-UPLOAD-URL"),
     uploadFile: vi.fn(),
-    deleteFile: vi.fn(),
+    copyObject: vi.fn().mockResolvedValue(undefined),
+    deleteObject: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockDomainEventPublisher = {
+    publishLibraryUploaded: vi.fn().mockResolvedValue(undefined),
   };
   let service: LibraryService;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new LibraryService(mockRepo, mockStorageService);
+    service = new LibraryService(
+      mockRepo,
+      mockStorageService,
+      mockDomainEventPublisher,
+    );
   });
 
   describe("getStats", () => {
@@ -110,6 +118,80 @@ describe("LibraryService", () => {
         .mockResolvedValue({ courses: {}, professors: [] });
       await service.getSearchMetadata();
       expect(mockRepo.getMetadata).toHaveBeenCalled();
+    });
+  });
+
+  describe("finalizeUploadedResource", () => {
+    it("copies temp key to final key, creates record, deletes temp, publishes event", async () => {
+      mockRepo.ensureMetadata = vi.fn().mockResolvedValue(undefined);
+      mockRepo.create = vi.fn().mockResolvedValue({ id: "doc-1" });
+
+      const record = await service.finalizeUploadedResource({
+        tempS3Key: "library/uploads/u/temp.pdf",
+        standardizedFilename: "Final_Name.pdf",
+        uploadedByDiscordId: "discord-1",
+        department: "CSCI",
+        course_number: "1200",
+        course_name: "Intro",
+        professor: "P",
+        semester: "Spring",
+        year: 2025,
+        type: "Exam1",
+        version: "Student",
+      });
+
+      expect(record).toEqual({ id: "doc-1" });
+      expect(mockRepo.ensureMetadata).toHaveBeenCalled();
+      expect(mockStorageService.copyObject).toHaveBeenCalledWith(
+        "library/uploads/u/temp.pdf",
+        "library/Final_Name.pdf",
+      );
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          file_s3_key: "library/Final_Name.pdf",
+          original_filename: "Final_Name.pdf",
+          uploaded_by: "discord-1",
+        }),
+      );
+      expect(mockStorageService.deleteObject).toHaveBeenCalledWith(
+        "library/uploads/u/temp.pdf",
+      );
+      expect(mockDomainEventPublisher.publishLibraryUploaded).toHaveBeenCalledWith(
+        {
+          userId: "discord-1",
+          resourceId: "doc-1",
+          fileName: "Final_Name.pdf",
+        },
+      );
+    });
+
+    it("on create failure, deletes promoted and temp keys", async () => {
+      mockRepo.ensureMetadata = vi.fn().mockResolvedValue(undefined);
+      mockRepo.create = vi.fn().mockRejectedValue(new Error("db down"));
+
+      await expect(
+        service.finalizeUploadedResource({
+          tempS3Key: "library/uploads/u/temp.pdf",
+          standardizedFilename: "x.pdf",
+          uploadedByDiscordId: "d1",
+          department: "CSCI",
+          course_number: "1200",
+          course_name: "Intro",
+          professor: "P",
+          semester: "Spring",
+          year: 2025,
+          type: "Exam1",
+          version: "Student",
+        }),
+      ).rejects.toThrow("db down");
+
+      expect(mockStorageService.deleteObject).toHaveBeenCalledWith(
+        "library/x.pdf",
+      );
+      expect(mockStorageService.deleteObject).toHaveBeenCalledWith(
+        "library/uploads/u/temp.pdf",
+      );
+      expect(mockDomainEventPublisher.publishLibraryUploaded).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/application/services/library/library.service.ts
+++ b/lib/application/services/library/library.service.ts
@@ -10,11 +10,14 @@ import { logger } from "@/lib/utils/logger";
 export type { LibrarySearchFilters, CreateResourceParams };
 
 import { IStorageService } from "@/lib/domain/ports/storage.service.port";
+import { IDomainEventPublisher } from "@/lib/domain/ports/domain-event.publisher.port";
+import { sanitizeLibraryUploadFilename } from "@/lib/utils/sanitize-library-upload-filename";
 
 export class LibraryService {
   constructor(
     private readonly libraryRepository: ILibraryRepository,
     private readonly storageService: IStorageService,
+    private readonly domainEventPublisher: IDomainEventPublisher,
   ) {}
 
   /**
@@ -120,5 +123,81 @@ export class LibraryService {
     version: string;
   }) {
     return await this.libraryRepository.exists(criteria);
+  }
+
+  /**
+   * Promotes a uniquely keyed staging upload to the canonical `library/` key,
+   * persists metadata, notifies subscribers, and removes the staging object.
+   */
+  async finalizeUploadedResource(input: {
+    tempS3Key: string;
+    standardizedFilename: string;
+    uploadedByDiscordId: string;
+    department: string;
+    course_number: string;
+    course_name: string;
+    professor: string;
+    semester: string;
+    year: number;
+    type: string;
+    version: string;
+  }): Promise<LibraryResource> {
+    const safeBasename = sanitizeLibraryUploadFilename(input.standardizedFilename);
+    const finalKey = `library/${safeBasename}`;
+
+    await this.libraryRepository.ensureMetadata({
+      department: input.department,
+      course_number: input.course_number,
+      course_name: input.course_name,
+      professor: input.professor,
+    });
+
+    try {
+      await this.storageService.copyObject(input.tempS3Key, finalKey);
+    } catch (e) {
+      logger.error("[library.finalize] copyObject failed", e);
+      await this.storageService.deleteObject(input.tempS3Key).catch(() => undefined);
+      throw e;
+    }
+
+    let record: LibraryResource;
+    try {
+      record = await this.libraryRepository.create({
+        department: input.department,
+        course_number: input.course_number,
+        course_name: input.course_name,
+        professor: input.professor,
+        semester: input.semester,
+        year: input.year,
+        type: input.type,
+        version: input.version,
+        original_filename: safeBasename,
+        file_s3_key: finalKey,
+        uploaded_by: input.uploadedByDiscordId,
+      });
+    } catch (e) {
+      logger.error("[library.finalize] create failed; removing promoted object", e);
+      await this.storageService.deleteObject(finalKey).catch(() => undefined);
+      await this.storageService.deleteObject(input.tempS3Key).catch(() => undefined);
+      throw e;
+    }
+
+    try {
+      await this.storageService.deleteObject(input.tempS3Key);
+    } catch (e) {
+      logger.error("[library.finalize] temp object delete failed (non-fatal)", e);
+    }
+
+    try {
+      await this.domainEventPublisher.publishLibraryUploaded({
+        userId: input.uploadedByDiscordId,
+        resourceId: record.id,
+        fileName: safeBasename,
+      });
+    } catch (e) {
+      logger.error("Failed to dispatch LIBRARY_UPLOADED event", e);
+    }
+
+    return record;
   }
 }

--- a/lib/domain/ports/domain-event.publisher.port.ts
+++ b/lib/domain/ports/domain-event.publisher.port.ts
@@ -1,0 +1,12 @@
+/**
+ * Outbound domain events from application services (implementation lives in infrastructure).
+ */
+export interface LibraryUploadedNotification {
+  userId: string;
+  resourceId: string;
+  fileName: string;
+}
+
+export interface IDomainEventPublisher {
+  publishLibraryUploaded(payload: LibraryUploadedNotification): Promise<void>;
+}

--- a/lib/domain/ports/storage.service.port.ts
+++ b/lib/domain/ports/storage.service.port.ts
@@ -18,4 +18,14 @@ export interface IStorageService {
     key: string,
     contentType: string,
   ): Promise<void>;
+
+  /**
+   * Copies an object within the same bucket (server-side promote).
+   */
+  copyObject(sourceKey: string, destinationKey: string): Promise<void>;
+
+  /**
+   * Deletes an object by key.
+   */
+  deleteObject(key: string): Promise<void>;
 }

--- a/lib/infrastructure/container.ts
+++ b/lib/infrastructure/container.ts
@@ -18,6 +18,7 @@ import { ITaskRepository } from "@/lib/domain/ports/task.repository";
 import { IUserRepository } from "@/lib/domain/ports/user.repository";
 import { ILedgerRepository } from "@/lib/domain/ports/ledger.repository";
 import { ILibraryRepository } from "@/lib/domain/ports/library.repository";
+import { IDomainEventPublisher } from "@/lib/domain/ports/domain-event.publisher.port";
 import { INotificationProvider } from "@/lib/domain/ports/notification.provider";
 import { IIdentityProvider } from "@/lib/domain/ports/identity.provider";
 import { IStorageService } from "@/lib/domain/ports/storage.service.port";
@@ -30,6 +31,7 @@ import { AppwriteLibraryRepository } from "./persistence/library.repository";
 import { DiscordProvider } from "./messaging/discord.provider";
 import { AppwriteIdentityProvider } from "./auth/appwrite.identity";
 import { S3StorageService } from "./storage/storage";
+import { AppwriteDomainEventPublisher } from "./events/domain-event.publisher";
 
 import {
   DutyService,
@@ -54,6 +56,7 @@ export interface Container {
   notificationProvider: INotificationProvider;
   identityProvider: IIdentityProvider;
   storageService: IStorageService;
+  domainEventPublisher: IDomainEventPublisher;
   // Services
   userService: UserService;
   dutyService: IDutyService;
@@ -86,6 +89,7 @@ export function getContainer(): Container {
     const notificationProvider = new DiscordProvider();
     const identityProvider = new AppwriteIdentityProvider();
     const storageService = new S3StorageService();
+    const domainEventPublisher = new AppwriteDomainEventPublisher();
 
     // 3. Services (Order matters!)
     const userService = new UserService(userRepository);
@@ -105,6 +109,7 @@ export function getContainer(): Container {
     const libraryService = new LibraryService(
       libraryRepository,
       storageService,
+      domainEventPublisher,
     );
     const cronService = new CronService(
       HousingTimeDrivenPipeline,
@@ -122,6 +127,7 @@ export function getContainer(): Container {
       notificationProvider,
       identityProvider,
       storageService,
+      domainEventPublisher,
       // Services
       userService,
       dutyService,

--- a/lib/infrastructure/events/domain-event.publisher.ts
+++ b/lib/infrastructure/events/domain-event.publisher.ts
@@ -1,0 +1,11 @@
+import { IDomainEventPublisher } from "@/lib/domain/ports/domain-event.publisher.port";
+import { LibraryEvents } from "@/lib/domain/events";
+import { DomainEventBus } from "./dispatcher";
+
+export class AppwriteDomainEventPublisher implements IDomainEventPublisher {
+  async publishLibraryUploaded(
+    payload: Parameters<IDomainEventPublisher["publishLibraryUploaded"]>[0],
+  ): Promise<void> {
+    await DomainEventBus.publish(LibraryEvents.LIBRARY_UPLOADED, payload);
+  }
+}

--- a/lib/infrastructure/storage/storage.ts
+++ b/lib/infrastructure/storage/storage.ts
@@ -8,6 +8,8 @@ import {
   S3Client,
   PutObjectCommand,
   GetObjectCommand,
+  CopyObjectCommand,
+  DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { env } from "@/lib/infrastructure/config/env";
@@ -64,6 +66,27 @@ export class S3StorageService implements IStorageService {
       Key: key,
       Body: buffer,
       ContentType: contentType,
+    });
+    await s3.send(command);
+  }
+
+  async copyObject(sourceKey: string, destinationKey: string): Promise<void> {
+    const encodedSourceKey = sourceKey
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    const command = new CopyObjectCommand({
+      Bucket: env.AWS_BUCKET_NAME,
+      CopySource: `${env.AWS_BUCKET_NAME}/${encodedSourceKey}`,
+      Key: destinationKey,
+    });
+    await s3.send(command);
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    const command = new DeleteObjectCommand({
+      Bucket: env.AWS_BUCKET_NAME,
+      Key: key,
     });
     await s3.send(command);
   }

--- a/lib/presentation/actions/library/manage.actions.test.ts
+++ b/lib/presentation/actions/library/manage.actions.test.ts
@@ -1,3 +1,4 @@
+import type { ActionContext } from "@/lib/presentation/utils/action-handler";
 import { actionWrapper } from "@/lib/presentation/utils/action-handler";
 import {
   presignLibraryUploadAction,
@@ -10,35 +11,60 @@ vi.mock("@/lib/presentation/utils/action-handler", () => ({
 
 describe("presignLibraryUploadAction", () => {
   const actionWrapperMock = vi.mocked(actionWrapper);
+  let ctx: ActionContext;
+
+  const makeContext = (): ActionContext => ({
+    container: {
+      storageService: {
+        getUploadUrl: vi.fn().mockResolvedValue("https://s3.example/presigned"),
+        getReadUrl: vi.fn(),
+        uploadFile: vi.fn(),
+        copyObject: vi.fn(),
+        deleteObject: vi.fn(),
+      },
+    } as unknown as ActionContext["container"],
+    userId: "user-1",
+    account: null,
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ctx = makeContext();
+    actionWrapperMock.mockImplementation(async (action) => {
+      try {
+        const data = await action(ctx);
+        return { success: true, data };
+      } catch (error) {
+        const msg =
+          error instanceof Error ? error.message : "An unexpected error occurred.";
+        return {
+          success: false,
+          error: msg,
+          errorCode: "UNKNOWN_ERROR" as const,
+        };
+      }
+    });
   });
 
-  it("returns upload URL and key on success", async () => {
-    actionWrapperMock.mockResolvedValue({
-      success: true,
-      data: {
-        key: "library/CSCI1200_Exam1.pdf",
-        uploadUrl: "https://s3.example/presigned",
-        sanitizedFilename: "CSCI1200_Exam1.pdf",
-      },
-    });
-
+  it("presigns a staging key and returns sanitized basename", async () => {
     const result = await presignLibraryUploadAction(
       { filename: "CSCI1200 Exam1.pdf" },
       "jwt",
     );
 
-    expect(result).toEqual({
-      key: "library/CSCI1200_Exam1.pdf",
-      uploadUrl: "https://s3.example/presigned",
-      sanitizedFilename: "CSCI1200_Exam1.pdf",
-    });
+    expect(result.sanitizedFilename).toBe("CSCI1200_Exam1.pdf");
+    expect(result.key).toMatch(
+      /^library\/uploads\/[0-9a-f-]{36}\/CSCI1200_Exam1\.pdf$/i,
+    );
+    expect(result.uploadUrl).toBe("https://s3.example/presigned");
+    expect(ctx.container.storageService.getUploadUrl).toHaveBeenCalledWith(
+      result.key,
+      "application/pdf",
+    );
   });
 
-  it("throws when actionWrapper fails", async () => {
-    actionWrapperMock.mockResolvedValue({
+  it("throws when actionWrapper returns failure envelope", async () => {
+    actionWrapperMock.mockResolvedValueOnce({
       success: false,
       error: "Unauthorized",
       errorCode: "INSUFFICIENT_ROLE",
@@ -52,20 +78,46 @@ describe("presignLibraryUploadAction", () => {
 
 describe("createLibraryResourceAction", () => {
   const actionWrapperMock = vi.mocked(actionWrapper);
+  let ctx: ActionContext;
+
+  const makeContext = (): ActionContext => ({
+    container: {
+      userService: {
+        getByAuthId: vi.fn().mockResolvedValue({ discord_id: "d1" }),
+      },
+      libraryService: {
+        finalizeUploadedResource: vi
+          .fn()
+          .mockResolvedValue({ id: "rec1" }),
+      },
+    } as unknown as ActionContext["container"],
+    userId: "auth-1",
+    account: null,
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ctx = makeContext();
+    actionWrapperMock.mockImplementation(async (action) => {
+      try {
+        const data = await action(ctx);
+        return { success: true, data };
+      } catch (error) {
+        const msg =
+          error instanceof Error ? error.message : "An unexpected error occurred.";
+        return {
+          success: false,
+          error: msg,
+          errorCode: "UNKNOWN_ERROR" as const,
+        };
+      }
+    });
   });
 
-  it("returns record on success", async () => {
-    actionWrapperMock.mockResolvedValue({
-      success: true,
-      data: { id: "rec1" },
-    });
-
+  it("delegates to libraryService.finalizeUploadedResource", async () => {
     const result = await createLibraryResourceAction(
       {
-        fileId: "library/x.pdf",
+        fileId: "library/uploads/uuid/x.pdf",
         metadata: {
           department: "CSCI",
           courseNumber: "1200",
@@ -82,10 +134,26 @@ describe("createLibraryResourceAction", () => {
     );
 
     expect(result).toEqual({ id: "rec1" });
+    expect(ctx.container.userService.getByAuthId).toHaveBeenCalledWith("auth-1");
+    expect(
+      ctx.container.libraryService.finalizeUploadedResource,
+    ).toHaveBeenCalledWith({
+      tempS3Key: "library/uploads/uuid/x.pdf",
+      standardizedFilename: "x.pdf",
+      uploadedByDiscordId: "d1",
+      department: "CSCI",
+      course_number: "1200",
+      course_name: "Intro",
+      professor: "P",
+      semester: "Spring",
+      year: 2025,
+      type: "Exam1",
+      version: "Student",
+    });
   });
 
-  it("throws when actionWrapper fails", async () => {
-    actionWrapperMock.mockResolvedValue({
+  it("throws when actionWrapper returns failure envelope", async () => {
+    actionWrapperMock.mockResolvedValueOnce({
       success: false,
       error: "some error",
       errorCode: "UNKNOWN_ERROR",

--- a/lib/presentation/actions/library/manage.actions.test.ts
+++ b/lib/presentation/actions/library/manage.actions.test.ts
@@ -1,0 +1,87 @@
+import { actionWrapper } from "@/lib/presentation/utils/action-handler";
+import {
+  presignLibraryUploadAction,
+  createLibraryResourceAction,
+} from "./manage.actions";
+
+vi.mock("@/lib/presentation/utils/action-handler", () => ({
+  actionWrapper: vi.fn(),
+}));
+
+describe("presignLibraryUploadAction", () => {
+  const actionWrapperMock = vi.mocked(actionWrapper);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns upload URL and key on success", async () => {
+    actionWrapperMock.mockResolvedValue({
+      success: true,
+      data: {
+        key: "library/CSCI1200_Exam1.pdf",
+        uploadUrl: "https://s3.example/presigned",
+      },
+    });
+
+    const result = await presignLibraryUploadAction(
+      { filename: "CSCI1200 Exam1.pdf", contentType: "application/pdf" },
+      "jwt",
+    );
+
+    expect(result).toEqual({
+      key: "library/CSCI1200_Exam1.pdf",
+      uploadUrl: "https://s3.example/presigned",
+    });
+  });
+
+  it("throws when actionWrapper fails", async () => {
+    actionWrapperMock.mockResolvedValue({
+      success: false,
+      error: "Unauthorized",
+      errorCode: "INSUFFICIENT_ROLE",
+    });
+
+    await expect(
+      presignLibraryUploadAction(
+        { filename: "a.pdf", contentType: "application/pdf" },
+        "jwt",
+      ),
+    ).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("createLibraryResourceAction", () => {
+  const actionWrapperMock = vi.mocked(actionWrapper);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns record on success", async () => {
+    actionWrapperMock.mockResolvedValue({
+      success: true,
+      data: { id: "rec1" },
+    });
+
+    const result = await createLibraryResourceAction(
+      {
+        fileId: "library/x.pdf",
+        metadata: {
+          department: "CSCI",
+          courseNumber: "1200",
+          courseName: "Intro",
+          professor: "P",
+          semester: "Spring",
+          year: 2025,
+          assessmentType: "Exam1",
+          version: "Student",
+          standardizedFilename: "x.pdf",
+        },
+      },
+      "jwt",
+    );
+
+    expect(result).toEqual({ id: "rec1" });
+  });
+});

--- a/lib/presentation/actions/library/manage.actions.test.ts
+++ b/lib/presentation/actions/library/manage.actions.test.ts
@@ -21,6 +21,7 @@ describe("presignLibraryUploadAction", () => {
       data: {
         key: "library/CSCI1200_Exam1.pdf",
         uploadUrl: "https://s3.example/presigned",
+        sanitizedFilename: "CSCI1200_Exam1.pdf",
       },
     });
 
@@ -32,6 +33,7 @@ describe("presignLibraryUploadAction", () => {
     expect(result).toEqual({
       key: "library/CSCI1200_Exam1.pdf",
       uploadUrl: "https://s3.example/presigned",
+      sanitizedFilename: "CSCI1200_Exam1.pdf",
     });
   });
 
@@ -83,5 +85,33 @@ describe("createLibraryResourceAction", () => {
     );
 
     expect(result).toEqual({ id: "rec1" });
+  });
+
+  it("throws when actionWrapper fails", async () => {
+    actionWrapperMock.mockResolvedValue({
+      success: false,
+      error: "some error",
+      errorCode: "UNKNOWN_ERROR",
+    });
+
+    await expect(
+      createLibraryResourceAction(
+        {
+          fileId: "library/x.pdf",
+          metadata: {
+            department: "CSCI",
+            courseNumber: "1200",
+            courseName: "Intro",
+            professor: "P",
+            semester: "Spring",
+            year: 2025,
+            assessmentType: "Exam1",
+            version: "Student",
+            standardizedFilename: "x.pdf",
+          },
+        },
+        "jwt",
+      ),
+    ).rejects.toThrow("some error");
   });
 });

--- a/lib/presentation/actions/library/manage.actions.test.ts
+++ b/lib/presentation/actions/library/manage.actions.test.ts
@@ -26,7 +26,7 @@ describe("presignLibraryUploadAction", () => {
     });
 
     const result = await presignLibraryUploadAction(
-      { filename: "CSCI1200 Exam1.pdf", contentType: "application/pdf" },
+      { filename: "CSCI1200 Exam1.pdf" },
       "jwt",
     );
 
@@ -45,10 +45,7 @@ describe("presignLibraryUploadAction", () => {
     });
 
     await expect(
-      presignLibraryUploadAction(
-        { filename: "a.pdf", contentType: "application/pdf" },
-        "jwt",
-      ),
+      presignLibraryUploadAction({ filename: "a.pdf" }, "jwt"),
     ).rejects.toThrow("Unauthorized");
   });
 });

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -3,35 +3,45 @@
 import { logger } from "@/lib/utils/logger";
 import { actionWrapper } from "@/lib/presentation/utils/action-handler";
 
+export type PresignLibraryUploadInput = {
+  filename: string;
+  contentType: string;
+};
+
+export type PresignLibraryUploadResult = {
+  key: string;
+  uploadUrl: string;
+};
+
 /**
- * Uploads a file to S3 and returns the Key/ID
+ * Issues a presigned PUT URL so the browser uploads directly to S3.
+ * Avoids sending the file through Vercel (serverless body limits ~4.5MB on Hobby).
  */
-export async function uploadFileAction(formData: FormData, jwt: string) {
-  try {
-    const result = await actionWrapper(
-      async ({ container }) => {
-        // 2. Process File
-        const file = formData.get("file") as File;
-        if (!file) throw new Error("No file uploaded");
+export async function presignLibraryUploadAction(
+  input: PresignLibraryUploadInput,
+  jwt: string,
+): Promise<PresignLibraryUploadResult> {
+  const result = await actionWrapper(
+    async ({ container }) => {
+      if (!input.filename?.trim()) {
+        throw new Error("No filename provided");
+      }
+      const safeName = input.filename.replace(/\s+/g, "_");
+      const key = `library/${safeName}`;
 
-        const buffer = Buffer.from(await file.arrayBuffer());
-        // Use 'library/' folder and keep original filename (sanitized)
-        const key = `library/${file.name.replace(/\s+/g, "_")}`;
+      const uploadUrl = await container.storageService.getUploadUrl(
+        key,
+        input.contentType || "application/pdf",
+      );
 
-        await container.storageService.uploadFile(buffer, key, file.type);
+      return { key, uploadUrl };
+    },
+    { jwt, actionName: "presignLibraryUpload" },
+  );
 
-        // Return an ID-like object to satisfy UI
-        return { $id: key, key: key };
-      },
-      { jwt },
-    );
-
-    if (result.success && result.data) return result.data;
-    throw new Error(result.error || "Upload failed");
-  } catch (e) {
-    logger.error("Upload Failed", e);
-    throw new Error("Failed to upload file");
-  }
+  if (result.success && result.data) return result.data;
+  logger.error("Library upload presign failed", result.error);
+  throw new Error(result.error || "Upload presign failed");
 }
 
 /**

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -20,7 +20,8 @@ export type PresignLibraryUploadResult = {
 };
 
 /**
- * Issues a presigned PUT URL so the browser uploads directly to S3.
+ * Issues a presigned PUT URL to a **staging** key (`library/uploads/<uuid>/…`).
+ * Finalize via `createLibraryResourceAction`, which promotes to `library/<sanitized>`.
  * Avoids sending the file through Vercel (serverless body limits ~4.5MB on Hobby).
  * S3 Content-Type is always `application/pdf` via `validatedLibraryUploadContentType()`.
  */

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { randomUUID } from "node:crypto";
+
 import { logger } from "@/lib/utils/logger";
 import { validatedLibraryUploadContentType } from "@/lib/utils/library-upload-content-type";
 import { sanitizeLibraryUploadFilename } from "@/lib/utils/sanitize-library-upload-filename";
@@ -10,9 +12,10 @@ export type PresignLibraryUploadInput = {
 };
 
 export type PresignLibraryUploadResult = {
+  /** Staging object key under `library/uploads/<uuid>/…`; pass to finalize as `fileId`. */
   key: string;
   uploadUrl: string;
-  /** Basename under `library/` after server-side sanitization (use for DB + display). */
+  /** Basename after sanitization; use for UI label (finalize copies to `library/<this>`). */
   sanitizedFilename: string;
 };
 
@@ -31,15 +34,19 @@ export async function presignLibraryUploadAction(
         throw new Error("No filename provided");
       }
       const safeName = sanitizeLibraryUploadFilename(input.filename);
-      const key = `library/${safeName}`;
+      const stagingKey = `library/uploads/${randomUUID()}/${safeName}`;
       const validatedContentType = validatedLibraryUploadContentType();
 
       const uploadUrl = await container.storageService.getUploadUrl(
-        key,
+        stagingKey,
         validatedContentType,
       );
 
-      return { key, uploadUrl, sanitizedFilename: safeName };
+      return {
+        key: stagingKey,
+        uploadUrl,
+        sanitizedFilename: safeName,
+      };
     },
     { jwt, actionName: "presignLibraryUpload" },
   );
@@ -73,51 +80,27 @@ export async function createLibraryResourceAction(
 ) {
   const result = await actionWrapper(
     async ({ container, userId }) => {
-      // 1. Ensure User Profile (Discord ID)
       const profile = await container.userService.getByAuthId(userId);
       if (!profile) throw new Error("Profile not found");
 
-      // 2. Ensure Dependents (Course/Professor) exist
-      await container.libraryService.ensureMetadata({
-        department: data.metadata.department,
-        course_number: data.metadata.courseNumber,
-        course_name: data.metadata.courseName,
-        professor: data.metadata.professor,
-      });
+      const year =
+        typeof data.metadata.year === "string"
+          ? parseInt(data.metadata.year)
+          : data.metadata.year;
 
-      // 3. Create Record
-      const record = await container.libraryService.createResource({
+      return await container.libraryService.finalizeUploadedResource({
+        tempS3Key: data.fileId,
+        standardizedFilename: data.metadata.standardizedFilename,
+        uploadedByDiscordId: profile.discord_id,
         department: data.metadata.department,
         course_number: data.metadata.courseNumber,
         course_name: data.metadata.courseName,
         professor: data.metadata.professor,
         semester: data.metadata.semester,
-        year:
-          typeof data.metadata.year === "string"
-            ? parseInt(data.metadata.year)
-            : data.metadata.year,
+        year,
         type: data.metadata.assessmentType,
         version: data.metadata.version,
-        original_filename: data.metadata.standardizedFilename,
-        file_s3_key: data.fileId,
-        uploaded_by: profile.discord_id,
       });
-
-      // 4. Dispatch Event (Event Architecture)
-      try {
-        const { DomainEventBus } =
-          await import("@/lib/infrastructure/events/dispatcher");
-        const { LibraryEvents } = await import("@/lib/domain/events");
-        await DomainEventBus.publish(LibraryEvents.LIBRARY_UPLOADED, {
-          userId: profile.discord_id,
-          resourceId: record.id,
-          fileName: data.metadata.standardizedFilename,
-        });
-      } catch (e) {
-        logger.error("Failed to dispatch LIBRARY_UPLOADED event", e);
-      }
-
-      return record;
     },
     { jwt, actionName: "createLibraryResource" },
   );

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -7,7 +7,6 @@ import { actionWrapper } from "@/lib/presentation/utils/action-handler";
 
 export type PresignLibraryUploadInput = {
   filename: string;
-  contentType: string;
 };
 
 export type PresignLibraryUploadResult = {
@@ -20,6 +19,7 @@ export type PresignLibraryUploadResult = {
 /**
  * Issues a presigned PUT URL so the browser uploads directly to S3.
  * Avoids sending the file through Vercel (serverless body limits ~4.5MB on Hobby).
+ * S3 Content-Type is always `application/pdf` via `validatedLibraryUploadContentType()`.
  */
 export async function presignLibraryUploadAction(
   input: PresignLibraryUploadInput,
@@ -73,11 +73,11 @@ export async function createLibraryResourceAction(
 ) {
   const result = await actionWrapper(
     async ({ container, userId }) => {
-      // 3. Ensure User Profile (Discord ID)
+      // 1. Ensure User Profile (Discord ID)
       const profile = await container.userService.getByAuthId(userId);
       if (!profile) throw new Error("Profile not found");
 
-      // 4. Ensure Dependents (Course/Professor) exist
+      // 2. Ensure Dependents (Course/Professor) exist
       await container.libraryService.ensureMetadata({
         department: data.metadata.department,
         course_number: data.metadata.courseNumber,
@@ -85,7 +85,7 @@ export async function createLibraryResourceAction(
         professor: data.metadata.professor,
       });
 
-      // 2. Create Record
+      // 3. Create Record
       const record = await container.libraryService.createResource({
         department: data.metadata.department,
         course_number: data.metadata.courseNumber,
@@ -103,7 +103,7 @@ export async function createLibraryResourceAction(
         uploaded_by: profile.discord_id,
       });
 
-      // 3. Dispatch Event (Event Architecture)
+      // 4. Dispatch Event (Event Architecture)
       try {
         const { DomainEventBus } =
           await import("@/lib/infrastructure/events/dispatcher");

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { logger } from "@/lib/utils/logger";
+import { validatedLibraryUploadContentType } from "@/lib/utils/library-upload-content-type";
 import { sanitizeLibraryUploadFilename } from "@/lib/utils/sanitize-library-upload-filename";
 import { actionWrapper } from "@/lib/presentation/utils/action-handler";
 
@@ -31,10 +32,13 @@ export async function presignLibraryUploadAction(
       }
       const safeName = sanitizeLibraryUploadFilename(input.filename);
       const key = `library/${safeName}`;
+      const validatedContentType = validatedLibraryUploadContentType(
+        input.contentType,
+      );
 
       const uploadUrl = await container.storageService.getUploadUrl(
         key,
-        input.contentType || "application/pdf",
+        validatedContentType,
       );
 
       return { key, uploadUrl, sanitizedFilename: safeName };

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -32,9 +32,7 @@ export async function presignLibraryUploadAction(
       }
       const safeName = sanitizeLibraryUploadFilename(input.filename);
       const key = `library/${safeName}`;
-      const validatedContentType = validatedLibraryUploadContentType(
-        input.contentType,
-      );
+      const validatedContentType = validatedLibraryUploadContentType();
 
       const uploadUrl = await container.storageService.getUploadUrl(
         key,
@@ -121,7 +119,7 @@ export async function createLibraryResourceAction(
 
       return record;
     },
-    { jwt },
+    { jwt, actionName: "createLibraryResource" },
   );
 
   if (result.success && result.data) return result.data;

--- a/lib/presentation/actions/library/manage.actions.ts
+++ b/lib/presentation/actions/library/manage.actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { logger } from "@/lib/utils/logger";
+import { sanitizeLibraryUploadFilename } from "@/lib/utils/sanitize-library-upload-filename";
 import { actionWrapper } from "@/lib/presentation/utils/action-handler";
 
 export type PresignLibraryUploadInput = {
@@ -11,6 +12,8 @@ export type PresignLibraryUploadInput = {
 export type PresignLibraryUploadResult = {
   key: string;
   uploadUrl: string;
+  /** Basename under `library/` after server-side sanitization (use for DB + display). */
+  sanitizedFilename: string;
 };
 
 /**
@@ -26,7 +29,7 @@ export async function presignLibraryUploadAction(
       if (!input.filename?.trim()) {
         throw new Error("No filename provided");
       }
-      const safeName = input.filename.replace(/\s+/g, "_");
+      const safeName = sanitizeLibraryUploadFilename(input.filename);
       const key = `library/${safeName}`;
 
       const uploadUrl = await container.storageService.getUploadUrl(
@@ -34,7 +37,7 @@ export async function presignLibraryUploadAction(
         input.contentType || "application/pdf",
       );
 
-      return { key, uploadUrl };
+      return { key, uploadUrl, sanitizedFilename: safeName };
     },
     { jwt, actionName: "presignLibraryUpload" },
   );

--- a/lib/presentation/utils/action-handler.ts
+++ b/lib/presentation/utils/action-handler.ts
@@ -6,7 +6,7 @@ interface AppwriteAccountClient {
   get: () => Promise<Models.User<Models.Preferences>>;
 }
 
-type ActionContext = {
+export type ActionContext = {
   container: Container;
   userId: string; // Auth ID when authenticated; empty string for public actions without JWT.
   account: AppwriteAccountClient | null; // Appwrite account client, not the user model

--- a/lib/utils/library-upload-content-type.test.ts
+++ b/lib/utils/library-upload-content-type.test.ts
@@ -1,0 +1,29 @@
+import { validatedLibraryUploadContentType } from "./library-upload-content-type";
+
+describe("validatedLibraryUploadContentType", () => {
+  it("returns application/pdf for application/pdf", () => {
+    expect(validatedLibraryUploadContentType("application/pdf")).toBe(
+      "application/pdf",
+    );
+  });
+
+  it("normalizes casing", () => {
+    expect(validatedLibraryUploadContentType("Application/PDF")).toBe(
+      "application/pdf",
+    );
+  });
+
+  it("defaults disallowed types to application/pdf", () => {
+    expect(validatedLibraryUploadContentType("image/png")).toBe(
+      "application/pdf",
+    );
+  });
+
+  it("defaults empty or whitespace to application/pdf", () => {
+    expect(validatedLibraryUploadContentType("")).toBe("application/pdf");
+    expect(validatedLibraryUploadContentType("   ")).toBe("application/pdf");
+    expect(validatedLibraryUploadContentType(undefined)).toBe(
+      "application/pdf",
+    );
+  });
+});

--- a/lib/utils/library-upload-content-type.test.ts
+++ b/lib/utils/library-upload-content-type.test.ts
@@ -1,29 +1,7 @@
 import { validatedLibraryUploadContentType } from "./library-upload-content-type";
 
 describe("validatedLibraryUploadContentType", () => {
-  it("returns application/pdf for application/pdf", () => {
-    expect(validatedLibraryUploadContentType("application/pdf")).toBe(
-      "application/pdf",
-    );
-  });
-
-  it("normalizes casing", () => {
-    expect(validatedLibraryUploadContentType("Application/PDF")).toBe(
-      "application/pdf",
-    );
-  });
-
-  it("defaults disallowed types to application/pdf", () => {
-    expect(validatedLibraryUploadContentType("image/png")).toBe(
-      "application/pdf",
-    );
-  });
-
-  it("defaults empty or whitespace to application/pdf", () => {
-    expect(validatedLibraryUploadContentType("")).toBe("application/pdf");
-    expect(validatedLibraryUploadContentType("   ")).toBe("application/pdf");
-    expect(validatedLibraryUploadContentType(undefined)).toBe(
-      "application/pdf",
-    );
+  it("always returns application/pdf for library uploads", () => {
+    expect(validatedLibraryUploadContentType()).toBe("application/pdf");
   });
 });

--- a/lib/utils/library-upload-content-type.ts
+++ b/lib/utils/library-upload-content-type.ts
@@ -1,16 +1,8 @@
-/** Library upload flow only supports PDF objects in S3. */
-const ALLOWED_LIBRARY_UPLOAD_CONTENT_TYPES = new Set(["application/pdf"]);
-
 /**
  * Normalizes client-supplied Content-Type for presigned PUT signing.
- * Unknown or empty values fall back to PDF so signatures match the upload page.
+ * Library uploads are PDF-only; always use application/pdf so the signature
+ * matches the browser PUT header.
  */
-export function validatedLibraryUploadContentType(
-  raw: string | undefined,
-): string {
-  const t = (raw ?? "").trim().toLowerCase();
-  if (ALLOWED_LIBRARY_UPLOAD_CONTENT_TYPES.has(t)) {
-    return "application/pdf";
-  }
+export function validatedLibraryUploadContentType(): string {
   return "application/pdf";
 }

--- a/lib/utils/library-upload-content-type.ts
+++ b/lib/utils/library-upload-content-type.ts
@@ -1,0 +1,16 @@
+/** Library upload flow only supports PDF objects in S3. */
+const ALLOWED_LIBRARY_UPLOAD_CONTENT_TYPES = new Set(["application/pdf"]);
+
+/**
+ * Normalizes client-supplied Content-Type for presigned PUT signing.
+ * Unknown or empty values fall back to PDF so signatures match the upload page.
+ */
+export function validatedLibraryUploadContentType(
+  raw: string | undefined,
+): string {
+  const t = (raw ?? "").trim().toLowerCase();
+  if (ALLOWED_LIBRARY_UPLOAD_CONTENT_TYPES.has(t)) {
+    return "application/pdf";
+  }
+  return "application/pdf";
+}

--- a/lib/utils/sanitize-library-upload-filename.test.ts
+++ b/lib/utils/sanitize-library-upload-filename.test.ts
@@ -1,0 +1,26 @@
+import { sanitizeLibraryUploadFilename } from "./sanitize-library-upload-filename";
+
+describe("sanitizeLibraryUploadFilename", () => {
+  it("preserves safe standardized exam-style names", () => {
+    expect(sanitizeLibraryUploadFilename("CSCI1200_Exam1_Cutler_Spring_2025_Student.pdf")).toBe(
+      "CSCI1200_Exam1_Cutler_Spring_2025_Student.pdf",
+    );
+  });
+
+  it("maps spaces and odd characters to single underscores", () => {
+    expect(sanitizeLibraryUploadFilename("CSCI1200 Exam1.pdf")).toBe("CSCI1200_Exam1.pdf");
+  });
+
+  it("uses basename only and strips traversal", () => {
+    expect(sanitizeLibraryUploadFilename("../../../etc/passwd.pdf")).toBe("passwd.pdf");
+  });
+
+  it("decodes percent-encoded slashes before taking basename", () => {
+    expect(sanitizeLibraryUploadFilename("x%2F..%2F..%2Fsecret.pdf")).toBe("secret.pdf");
+  });
+
+  it("returns a non-empty fallback when nothing safe remains", () => {
+    const out = sanitizeLibraryUploadFilename("..../");
+    expect(out).toMatch(/^upload-[0-9a-f-]{36}\.pdf$/i);
+  });
+});

--- a/lib/utils/sanitize-library-upload-filename.test.ts
+++ b/lib/utils/sanitize-library-upload-filename.test.ts
@@ -23,4 +23,29 @@ describe("sanitizeLibraryUploadFilename", () => {
     const out = sanitizeLibraryUploadFilename("..../");
     expect(out).toMatch(/^upload-[0-9a-f-]{36}\.pdf$/i);
   });
+
+  it("removes null bytes", () => {
+    expect(sanitizeLibraryUploadFilename("foo\0bar.pdf")).toBe("foobar.pdf");
+  });
+
+  it("strips ASCII control characters", () => {
+    expect(sanitizeLibraryUploadFilename("foo\x01\x1Fbar.pdf")).toBe(
+      "foobar.pdf",
+    );
+    expect(sanitizeLibraryUploadFilename("foo\x7Fbar.pdf")).toBe("foobar.pdf");
+  });
+
+  it("truncates basenames longer than 200 characters", () => {
+    const long = `${"a".repeat(250)}.pdf`;
+    const out = sanitizeLibraryUploadFilename(long);
+    expect(out.length).toBeLessThanOrEqual(200);
+  });
+
+  it("collapses consecutive dots to a single underscore", () => {
+    expect(sanitizeLibraryUploadFilename("foo..bar.pdf")).toBe("foo_bar.pdf");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    expect(sanitizeLibraryUploadFilename("foo---bar.pdf")).toBe("foo-bar.pdf");
+  });
 });

--- a/lib/utils/sanitize-library-upload-filename.ts
+++ b/lib/utils/sanitize-library-upload-filename.ts
@@ -37,6 +37,7 @@ export function sanitizeLibraryUploadFilename(original: string): string {
 
   cleaned = cleaned.replace(/\.\.+/g, "_");
   cleaned = cleaned.replace(/_+/g, "_");
+  cleaned = cleaned.replace(/-+/g, "-");
   cleaned = cleaned.replace(/^[._-]+|[._-]+$/g, "");
 
   if (cleaned.length > MAX_OBJECT_BASENAME_LENGTH) {

--- a/lib/utils/sanitize-library-upload-filename.ts
+++ b/lib/utils/sanitize-library-upload-filename.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto";
+
+const MAX_OBJECT_BASENAME_LENGTH = 200;
+
+/**
+ * Produces a single path segment safe for S3 keys under `library/`.
+ * Prevents path traversal, control characters, and unexpected encodings in client-supplied names.
+ */
+export function sanitizeLibraryUploadFilename(original: string): string {
+  let s = original.normalize("NFKC");
+
+  for (let i = 0; i < 8; i += 1) {
+    try {
+      const decoded = decodeURIComponent(s);
+      if (decoded === s) break;
+      s = decoded;
+    } catch {
+      break;
+    }
+  }
+
+  s = s.replace(/\\/g, "/");
+  s = s.replace(/\0/g, "");
+  s = s.replace(/[\u0001-\u001F\u007F]/g, "");
+
+  const segments = s.split("/").filter((seg) => seg.length > 0);
+  const base = segments.length > 0 ? (segments.at(-1) ?? s) : s;
+
+  let cleaned = "";
+  for (const ch of base) {
+    if (/^[a-zA-Z0-9._-]$/.test(ch)) {
+      cleaned += ch;
+    } else {
+      cleaned += "_";
+    }
+  }
+
+  cleaned = cleaned.replace(/\.\.+/g, "_");
+  cleaned = cleaned.replace(/_+/g, "_");
+  cleaned = cleaned.replace(/^[._-]+|[._-]+$/g, "");
+
+  if (cleaned.length > MAX_OBJECT_BASENAME_LENGTH) {
+    cleaned = cleaned.slice(0, MAX_OBJECT_BASENAME_LENGTH).replace(/[._-]+$/g, "");
+  }
+
+  if (!cleaned) {
+    return `upload-${randomUUID()}.pdf`;
+  }
+
+  return cleaned;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,7 +30,7 @@ const nextConfig: NextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://cloud.appwrite.io https://appwrite.taunufiji.app https://cdn.discordapp.com; font-src 'self'; connect-src 'self' https://appwrite.taunufiji.app https://cloud.appwrite.io;",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://cloud.appwrite.io https://appwrite.taunufiji.app https://cdn.discordapp.com; font-src 'self'; connect-src 'self' https://*.amazonaws.com https://appwrite.taunufiji.app https://cloud.appwrite.io;",
           },
         ],
       },

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -13,7 +13,7 @@ Presentation → Application → Domain ← Infrastructure
 The heart of the software. Has **no imports from infrastructure, application, or presentation layers**.
 
 - **Entities**: Pure TypeScript classes defining core business objects (`HousingTask`, `LedgerEntry`).
-- **Ports**: Interface definitions for external systems (`ITaskRepository`, `INotificationProvider`).
+- **Ports**: Interface definitions for external systems (`ITaskRepository`, `INotificationProvider`, `IDomainEventPublisher` for application-triggered outbound events such as library upload notifications).
 - **Types / DTOs**: Zod schemas (`lib/domain/types/`) define the canonical shape of domain objects (e.g., `BaseEntitySchema`, `TaskSchema`). Zod is the sole external dependency in this layer — it is used for schema _definition and type inference_ (`z.infer<…>`). Runtime validation of input payloads destined for Server Actions happens in the presentation layer; the domain schemas serve as the single source of truth for the data contracts shared across layers.
 
 ### 2. Application Layer (`lib/application`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Library exam uploads used a Server Action that read the entire PDF into a `Buffer` on Vercel. Vercel’s **platform** request body cap (~4.5MB on Hobby) applies independently of Next’s `serverActions.bodySizeLimit`.

## Solution

- **Presign** → unique **staging** key `library/uploads/<uuid>/<sanitized>.pdf`; browser PUTs there.
- **Finalize** (`createLibraryResourceAction`) → `LibraryService.finalizeUploadedResource`: server-side **copy** to `library/<sanitized>`, **create** Appwrite row, **delete** staging; on DB failure deletes promoted + staging copies.
- **Events**: `IDomainEventPublisher` port + `AppwriteDomainEventPublisher` (infrastructure) calls `DomainEventBus`; presentation no longer imports the bus.
- **Storage port**: `copyObject` / `deleteObject` on `IStorageService` (S3 implementation).
- **Tests**: `manage.actions.test.ts` mocks `actionWrapper` to **invoke** the real action callback with a fake container; `library.service.test.ts` covers finalize happy path and create failure cleanup.

## Verification

- `npm run lint`, `npx tsc --noEmit`, `npm run test -- --run`, `SKIP_ENV_VALIDATION=true npm run build`

## Deploy / ops

- S3 bucket needs **s3:GetObject**, **s3:PutObject**, **s3:DeleteObject**, **s3:CopyObject** (or equivalent) for app keys under `library/`.
- CORS: see `docs/deployment/environments.md` (PUT, Content-Type, ETag; preview wildcard note).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-764b95bc-d25f-4fb8-b476-97231c0b843f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-764b95bc-d25f-4fb8-b476-97231c0b843f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library uploads now use presigned direct-to-storage PUTs with client-side retries, clearer failure messages, and sanitized filenames included in resource metadata.
  * Uploads standardize content type to application/pdf.

* **Documentation**
  * Deployment docs updated with required S3 CORS settings (including PUT, Content-Type, exposed headers) and preview host guidance.

* **Tests**
  * Added tests for presign/create actions, filename sanitization, and upload content-type validation.

* **Chores**
  * Content-Security-Policy broadened to allow cloud storage endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->