### PR TITLE
docs: Appwrite custom domain TLS troubleshooting after project pause

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -44,6 +44,22 @@ This is often **cold start** or heavy SSR on the first hit after idle.
    - confirm the configured role IDs exist in the guild.
 4. Re-run diagnostics and then re-test task creation in staging UI.
 
+### Symptom: After "Log in with Discord", the browser shows "Your connection is not private" for `appwrite.<your-domain>` (`NET::ERR_CERT_DATE_INVALID`)
+
+This is **not** a Vercel or Next.js bug. Discord OAuth sends the browser to your **Appwrite** API hostname (for this project, the custom domain `https://appwrite.taunufiji.app`). Appwrite Cloud terminates TLS for that hostname. If the certificate **expires** or has the wrong **notBefore** / **notAfter** window, Chrome reports `NET::ERR_CERT_DATE_INVALID` and login cannot complete.
+
+**Common trigger:** Appwrite **paused** the project briefly; automated certificate renewal can miss a cycle or leave the custom domain on an expired cert until it is refreshed.
+
+**What to do:**
+
+1. In **Appwrite Console** → your project → **Settings** (or **Domains** / **Custom domains**, depending on console version) → open the **`appwrite.*` custom domain** used as `NEXT_PUBLIC_APPWRITE_ENDPOINT`.
+2. Confirm DNS still matches Appwrite’s required records (usually a **CNAME** to Appwrite’s target). Do not point that hostname at Vercel; the app on Vercel only **calls** this URL over HTTPS.
+3. **Refresh the certificate:** remove and re-add the custom domain, or use any **Verify / Renew certificate** control Appwrite exposes. Wait until the console shows the domain verified and HTTPS healthy, then retry login.
+
+**Sanity check (terminal):** `echo | openssl s_client -connect appwrite.<your-domain>:443 -servername appwrite.<your-domain> 2>/dev/null | openssl x509 -noout -dates` — ensure `notAfter` is in the future.
+
+**Vercel:** Production domains for the Next.js app (`taunufiji.app` → `www.taunufiji.app`, etc.) can still be correct while the Appwrite subdomain fails; fix the Appwrite side for auth.
+
 ### Symptom: User can view dashboard but mutation fails with authorization
 
 1. Verify the user has the Brother role for baseline access.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a troubleshooting section for the Discord login flow failing with Chrome's "Your connection is not private" and `NET::ERR_CERT_DATE_INVALID` on the Appwrite API hostname (e.g. `appwrite.taunufiji.app`).

## Investigation (for reviewers)

- Verified `appwrite.taunufiji.app` presents an **expired** TLS certificate (`notAfter` 2026-04-16); today is 2026-04-18. That matches the reported error code.
- Vercel project `taunufiji-dot-app` domains look correct: `taunufiji.app` → `www.taunufiji.app`, `www` verified; `www` cert is valid through June 2026. The issue is **Appwrite-hosted** TLS for the custom API domain, not Vercel.
- **User action:** In Appwrite Console, refresh the custom domain / certificate (re-verify DNS, remove and re-add domain, or use Appwrite's renew flow).

## Changes

- `docs/deployment/troubleshooting.md`: new symptom runbook with openssl sanity check.

## Testing

- `npm run lint`
- `npx tsc --noEmit`
- `npm run test -- --run`
- `npm run test:coverage:critical`
- `npm run test:e2e`
- `SKIP_ENV_VALIDATION=true npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fe3a849-c1c1-464e-8c89-a8eb2cd5cff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fe3a849-c1c1-464e-8c89-a8eb2cd5cff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

