### PR TITLE
feat(ops): detect expired Appwrite TLS in staging diagnostics

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -16,6 +16,7 @@ Exit code `0` prints a line per check with pass/fail; exit code `1` if validatio
 
 What it verifies today:
 
+- TLS certificate validity for the Appwrite endpoint host (catches expired certs that break Discord OAuth in the browser)
 - Appwrite admin access to critical collections (`users`, `assignments`)
 - Discord guild reachability with bot token
 - Discord housing channel reachability
@@ -24,6 +25,27 @@ What it verifies today:
 If this command fails, do not merge **`main` → `production`** (do not ship the Vercel Production deployment) until the failing checks are resolved. This script targets the same staging-oriented credentials as `npm run diagnose:staging` suggests—**`main`** is the integration branch; there is no separate “promote staging branch” step in the documented flow.
 
 ## Staging Troubleshooting Runbook
+
+### Symptom: "Your connection is not private" / `NET::ERR_CERT_DATE_INVALID` on the Appwrite host (e.g. `appwrite.example.com`)
+
+The Next.js app on **Vercel** is separate from **Appwrite Cloud**. OAuth and the Appwrite web SDK talk to whatever host is in `NEXT_PUBLIC_APPWRITE_ENDPOINT`. If that host’s **TLS certificate is expired or not yet valid**, the browser blocks the connection before any application code runs — login with Discord fails with a certificate warning.
+
+**What `NET::ERR_CERT_DATE_INVALID` means:** the browser does not trust the server’s certificate dates (usually **expired**, occasionally clock skew on the client).
+
+**How to confirm from a shell (replace the host with your endpoint hostname, no `/v1` path):**
+
+```bash
+echo | openssl s_client -servername appwrite.example.com -connect appwrite.example.com:443 2>/dev/null \
+  | openssl x509 -noout -dates -subject
+```
+
+**Typical causes after an Appwrite project pause:** automatic certificate renewal (ACME) may not run while the project is suspended; the cert can expire shortly after.
+
+**What to do:**
+
+1. In **Appwrite Console** → your project → **Settings** (or **Domains** / custom hostname): open the **custom domain** used in `NEXT_PUBLIC_APPWRITE_ENDPOINT`, ensure it is **verified**, and use any **renew / refresh certificate** option if shown. Re-saving or toggling verification can trigger a new cert.
+2. Ensure **DNS** for that hostname still matches Appwrite’s documented target (usually a **CNAME** to your region’s `*.cloud.appwrite.io`). This hostname is **not** a Vercel project domain — the Vercel “domain configuration” checker may label a CNAME to Appwrite as “misconfigured” because it expects Vercel’s own records; that warning does **not** apply to traffic that should terminate on Appwrite.
+3. Run `npm run diagnose:staging` — it fails fast if the Appwrite endpoint certificate is expired or expiring within 14 days.
 
 ### Symptom: Deploy succeeds but first request is slow or times out
 

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -26,26 +26,31 @@ If this command fails, do not merge **`main` → `production`** (do not ship the
 
 ## Staging Troubleshooting Runbook
 
-### Symptom: "Your connection is not private" / `NET::ERR_CERT_DATE_INVALID` on the Appwrite host (e.g. `appwrite.example.com`)
+### Symptom: "Your connection is not private" / `NET::ERR_CERT_DATE_INVALID` on the Appwrite API host (e.g. `appwrite.example.com`)
 
-The Next.js app on **Vercel** is separate from **Appwrite Cloud**. OAuth and the Appwrite web SDK talk to whatever host is in `NEXT_PUBLIC_APPWRITE_ENDPOINT`. If that host’s **TLS certificate is expired or not yet valid**, the browser blocks the connection before any application code runs — login with Discord fails with a certificate warning.
+The Next.js app on **Vercel** is separate from **Appwrite Cloud**. OAuth and the Appwrite web SDK use whatever host is in `NEXT_PUBLIC_APPWRITE_ENDPOINT`. If that host’s **TLS certificate is expired or not yet valid**, the browser blocks HTTPS before any application code runs.
 
-**What `NET::ERR_CERT_DATE_INVALID` means:** the browser does not trust the server’s certificate dates (usually **expired**, occasionally clock skew on the client).
+**What `NET::ERR_CERT_DATE_INVALID` means:** the browser rejects the certificate’s validity window (usually **expired**).
 
-**How to confirm from a shell (replace the host with your endpoint hostname, no `/v1` path):**
+**Who must issue the certificate (important):** TLS is terminated by whoever answers **HTTPS on the IPs your DNS resolves to**. If DNS is a **CNAME to** `*.cloud.appwrite.io`, the certificate you see in the browser is **Appwrite’s** (on their edge), not Vercel’s — even when **DNS records** are edited in **Vercel DNS** because the zone uses Vercel nameservers. Managing DNS in Vercel does **not** move TLS termination to Vercel unless you **change** that CNAME to point at Vercel (which would break the Appwrite API on that hostname).
+
+**How to confirm from a shell (use your endpoint hostname, no `/v1` path):**
 
 ```bash
 echo | openssl s_client -servername appwrite.example.com -connect appwrite.example.com:443 2>/dev/null \
-  | openssl x509 -noout -dates -subject
+  | openssl x509 -noout -dates -subject -issuer
 ```
 
-**Typical causes after an Appwrite project pause:** automatic certificate renewal (ACME) may not run while the project is suspended; the cert can expire shortly after.
+**Typical causes after an Appwrite project pause:** automatic certificate renewal may not complete while the project is suspended; the cert can expire shortly after.
 
 **What to do:**
 
-1. In **Appwrite Console** → your project → **Settings** (or **Domains** / custom hostname): open the **custom domain** used in `NEXT_PUBLIC_APPWRITE_ENDPOINT`, ensure it is **verified**, and use any **renew / refresh certificate** option if shown. Re-saving or toggling verification can trigger a new cert.
-2. Ensure **DNS** for that hostname still matches Appwrite’s documented target (usually a **CNAME** to your region’s `*.cloud.appwrite.io`). This hostname is **not** a Vercel project domain — the Vercel “domain configuration” checker may label a CNAME to Appwrite as “misconfigured” because it expects Vercel’s own records; that warning does **not** apply to traffic that should terminate on Appwrite.
-3. Run `npm run diagnose:staging` — it fails fast if the Appwrite endpoint certificate is expired or expiring within 14 days.
+1. **Appwrite Console** (not the registrar): Project → **Settings** → **Custom domains** for the hostname in `NEXT_PUBLIC_APPWRITE_ENDPOINT`. Use **Generate SSL certificate** / renew / re-verify if the UI offers it. You do **not** delegate the apex domain to Appwrite; you only register the hostname **inside** the Appwrite project and point **DNS** at their target (same pattern as [Appwrite custom domains](https://appwrite.io/docs/advanced/platform/custom-domains)).
+2. Keep **DNS** aligned with that doc (usually a **CNAME** to your region’s `*.cloud.appwrite.io`). The Vercel “domain configuration” API may show **`misconfigured: true`** for such a CNAME because it assumes the hostname is for a Vercel deployment; ignore that for Appwrite-only hostnames.
+3. **Server API keys** in this repo cannot renew certificates (they lack `projects.read` / domain scopes on the Appwrite API). Renewal is console-side or Appwrite support.
+4. Run `npm run diagnose:staging` — it fails fast if the Appwrite endpoint certificate is expired or expiring within 14 days.
+
+**Emergency workaround (cookie / third-party caveats):** point `NEXT_PUBLIC_APPWRITE_ENDPOINT` at your regional `https://<region>.cloud.appwrite.io/v1` in Vercel env and redeploy. Prefer fixing the custom domain when possible; see [Appwrite third-party cookies](https://appwrite.io/docs/advanced/platform/custom-domains#third-party-cookies) for why same-site API hostnames exist.
 
 ### Symptom: Deploy succeeds but first request is slow or times out
 

--- a/scripts/diagnose-staging.ts
+++ b/scripts/diagnose-staging.ts
@@ -1,3 +1,4 @@
+import tls from "node:tls";
 import { config as loadDotEnv } from "dotenv";
 import { Databases, Query } from "node-appwrite";
 import { DB_ID, COLLECTIONS } from "@/lib/infrastructure/config/schema";
@@ -17,6 +18,120 @@ type DiagnosticResult = {
 const DISCORD_API = "https://discord.com/api/v10";
 const REQUEST_TIMEOUT_MS = 8_000;
 const RESPONSE_BODY_SNIPPET_MAX_LENGTH = 300;
+const TLS_CERT_WARNING_DAYS = 14;
+
+function parseCertDate(value: string | undefined): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+async function runAppwriteEndpointTlsCheck(host: string): Promise<DiagnosticResult> {
+  const checkName = "Appwrite endpoint TLS certificate";
+  return await new Promise((resolve) => {
+    const socket = tls.connect({
+      host,
+      port: 443,
+      servername: host,
+      rejectUnauthorized: false,
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+
+    const finish = (result: DiagnosticResult): void => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.once("timeout", () => {
+      finish({
+        check: checkName,
+        passed: false,
+        detail: `TLS handshake timed out after ${REQUEST_TIMEOUT_MS}ms`,
+      });
+    });
+
+    socket.once("error", (error: Error) => {
+      finish({
+        check: checkName,
+        passed: false,
+        detail: error.message,
+      });
+    });
+
+    socket.once("secureConnect", () => {
+      const raw = socket.getPeerCertificate();
+      socket.end();
+
+      if (!raw || Object.keys(raw).length === 0) {
+        finish({
+          check: checkName,
+          passed: false,
+          detail: "Peer did not present a certificate",
+        });
+        return;
+      }
+
+      const notBefore = parseCertDate(raw.valid_from);
+      const notAfter = parseCertDate(raw.valid_to);
+      if (!notBefore || !notAfter) {
+        finish({
+          check: checkName,
+          passed: false,
+          detail: "Certificate missing valid_from / valid_to",
+        });
+        return;
+      }
+
+      const now = new Date();
+      const subject =
+        typeof raw.subject?.CN === "string"
+          ? raw.subject.CN
+          : typeof raw.subject === "string"
+            ? raw.subject
+            : host;
+
+      if (now < notBefore) {
+        finish({
+          check: checkName,
+          passed: false,
+          detail: `Certificate for ${subject} is not yet valid (starts ${notBefore.toISOString()})`,
+        });
+        return;
+      }
+
+      if (now > notAfter) {
+        finish({
+          check: checkName,
+          passed: false,
+          detail: `Certificate for ${subject} expired ${notAfter.toISOString()} — browsers show NET::ERR_CERT_DATE_INVALID; renew TLS in Appwrite (custom domain) after outages`,
+        });
+        return;
+      }
+
+      const daysRemaining =
+        (notAfter.getTime() - now.getTime()) / (86_400_000);
+      const expiresSummary = `expires ${notAfter.toISOString()} (${Math.floor(daysRemaining)}d remaining)`;
+
+      if (daysRemaining <= TLS_CERT_WARNING_DAYS) {
+        finish({
+          check: checkName,
+          passed: false,
+          detail: `Certificate for ${subject} ${expiresSummary} — renew soon to avoid login failures`,
+        });
+        return;
+      }
+
+      finish({
+        check: checkName,
+        passed: true,
+        detail: `Certificate for ${subject} ${expiresSummary}`,
+      });
+    });
+  });
+}
 
 function safeErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -306,6 +421,7 @@ async function main(): Promise<void> {
   const databases = new Databases(createAppwriteAdminClientFromEnv());
 
   const results: DiagnosticResult[] = [
+    await runAppwriteEndpointTlsCheck(endpointHost),
     ...(await runAppwriteChecks(databases)),
     ...(await runDiscordChecks(env)),
   ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies troubleshooting for `NET::ERR_CERT_DATE_INVALID` on Appwrite API hostnames: Vercel DNS does not mean Vercel terminates TLS when the CNAME targets Appwrite Cloud. Adds staging TLS check in `npm run diagnose:staging` (from earlier commit on this branch).

## Doc updates

- Who issues the cert (follow DNS target, check `openssl` issuer).
- Appwrite Console custom domain / SSL generation (no registrar delegation required).
- Why server API keys cannot renew certs; optional regional `*.cloud.appwrite.io` workaround with cookie caveats.

## Operator notes

Live checks from the agent VM: `appwrite.taunufiji.app` CNAME → `nyc.cloud.appwrite.io`, cert issuer **Certainly** (Appwrite edge), **expired** `notAfter=Apr 16 2026`. Adding the hostname to the Vercel project + `POST /v7/certs` minted a Vercel cert but **did not** change the served cert until DNS would point at Vercel — so the fix remains renewing the cert on the Appwrite side for the current DNS layout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db378601-9a06-4dc5-9e60-be56363401bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db378601-9a06-4dc5-9e60-be56363401bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

